### PR TITLE
Feat #24 : 토큰 생성 및 검증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/dayone/dayone/auth/exception/TokenErrorCode.java
+++ b/src/main/java/dayone/dayone/auth/exception/TokenErrorCode.java
@@ -1,0 +1,35 @@
+package dayone.dayone.auth.exception;
+
+import dayone.dayone.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum TokenErrorCode implements ErrorCode {
+
+    NOT_ISSUED_TOKEN(HttpStatus.BAD_REQUEST, 3001, "서비스 내에서 발급한 토큰이 아닙니다"),
+    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, 3002, "만료된 토큰 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    TokenErrorCode(final HttpStatus httpStatus, final int code, final String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/dayone/dayone/auth/exception/TokenException.java
+++ b/src/main/java/dayone/dayone/auth/exception/TokenException.java
@@ -1,0 +1,11 @@
+package dayone.dayone.auth.exception;
+
+import dayone.dayone.global.exception.CommonException;
+import dayone.dayone.global.exception.ErrorCode;
+
+public class TokenException extends CommonException {
+
+    public TokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/dayone/dayone/auth/token/TokenProvider.java
+++ b/src/main/java/dayone/dayone/auth/token/TokenProvider.java
@@ -1,0 +1,73 @@
+package dayone.dayone.auth.token;
+
+import dayone.dayone.auth.exception.TokenErrorCode;
+import dayone.dayone.auth.exception.TokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class TokenProvider {
+
+    private final long accessTokenValidTime;
+    private final long refreshTokenValidTime;
+    private final Key secretKey;
+
+    public TokenProvider(
+        @Value("${jwt.access-token-valid-time}") final long accessTokenValidTime,
+        @Value("${jwt.refresh-token-valid-time}") final long refreshTokenValidTime,
+        @Value("${jwt.secret-code}") final String secretCode
+    ) {
+        this.accessTokenValidTime = accessTokenValidTime;
+        this.refreshTokenValidTime = refreshTokenValidTime;
+        this.secretKey = generateSecretKey(secretCode);
+    }
+
+    private Key generateSecretKey(final String secretCode) {
+        final String encodedSecretCode = Base64.getEncoder().encodeToString(secretCode.getBytes());
+        return Keys.hmacShaKeyFor(encodedSecretCode.getBytes());
+    }
+
+    public String createAccessToken(final long memberId) {
+        return createToken(memberId, accessTokenValidTime);
+    }
+
+    public String createRefreshToken(final long memberId) {
+        return createToken(memberId, refreshTokenValidTime);
+    }
+
+    private String createToken(final long memberId, final long validTime) {
+        final Claims claims = Jwts.claims().setSubject("user");
+        claims.put("memberId", memberId);
+        final Date now = new Date();
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + validTime))
+            .signWith(secretKey, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public Claims parseClaims(final String token) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        } catch (MalformedJwtException e) {
+            throw new TokenException(TokenErrorCode.NOT_ISSUED_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new TokenException(TokenErrorCode.EXPIRED_TOKEN);
+        }
+    }
+}

--- a/src/test/java/dayone/dayone/auth/token/TokenProviderTest.java
+++ b/src/test/java/dayone/dayone/auth/token/TokenProviderTest.java
@@ -1,0 +1,79 @@
+package dayone.dayone.auth.token;
+
+import dayone.dayone.auth.exception.TokenErrorCode;
+import dayone.dayone.auth.exception.TokenException;
+import io.jsonwebtoken.Claims;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TokenProviderTest {
+
+    @DisplayName("access token을 생성한다.")
+    @Test
+    void createAccessToken() {
+        // given
+        final TokenProvider tokenProvider = new TokenProvider(10000, 100000, "secretCodeaesb231dbdsd");
+
+        // when
+        final String accessToken = tokenProvider.createAccessToken(1);
+
+        // then
+        final Claims claims = tokenProvider.parseClaims(accessToken);
+
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(claims.get("memberId")).isEqualTo(1);
+            softAssertions.assertThat(claims.getExpiration()).isAfter(new Date());
+        });
+    }
+
+    @DisplayName("refresh token을 생성한다.")
+    @Test
+    void createRefreshToken() {
+        // given
+        final TokenProvider tokenProvider = new TokenProvider(10000, 100000, "secretCodeaesb231dbdsd");
+
+        // when
+        final String refreshToken = tokenProvider.createRefreshToken(1);
+
+        // then
+        final Claims claims = tokenProvider.parseClaims(refreshToken);
+
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(claims.get("memberId")).isEqualTo(1);
+            softAssertions.assertThat(claims.getExpiration()).isAfter(new Date());
+        });
+    }
+
+    @DisplayName("잘못된 토큰을 분해하면 MalformedTokenException 예외를 발생한다.")
+    @Test
+    void MalformedTokenException() {
+        // given
+        final TokenProvider tokenProvider = new TokenProvider(10000, 100000, "secretCodeaesb231dbdsd");
+        final String wrongToken = "wrongToken.wrongToken.wrongToken";
+
+        // when
+        // then
+        assertThatThrownBy(() -> tokenProvider.parseClaims(wrongToken))
+            .isInstanceOf(TokenException.class)
+            .hasMessage(TokenErrorCode.NOT_ISSUED_TOKEN.getMessage());
+    }
+
+    @DisplayName("토큰 기간이 만료되면 ExpiredTokenException 예외를 발생한다.")
+    @Test
+    void ExpiredTokenException() {
+        // given
+        final TokenProvider expiredTokenProvider = new TokenProvider(0, 0, "secretCodeaesb231dbdsd");
+        final String expiredAccessToken = expiredTokenProvider.createAccessToken(1);
+
+        // when
+        // then
+        assertThatThrownBy(() -> expiredTokenProvider.parseClaims(expiredAccessToken))
+            .isInstanceOf(TokenException.class)
+            .hasMessage(TokenErrorCode.EXPIRED_TOKEN.getMessage());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -20,3 +20,8 @@ naver:
   book-search-url: http://api.com
   client-id: clientId
   client-secret: clientSecret
+
+jwt:
+  access-token-valid-time: 10000
+  refresh-token-valid-time: 100000
+  secret-code: json-web-token-secret-code-for-test


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- login 작업처리에 앞서서 jwt 토큰을 생성 및 검증 기능을 추가했습니다.

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항

- session 인증 방식과 jwt 인증 방식을 고려하던 중에 jwt 방식을 채택한 이유
   - 현재 본 서비스의 배포전략은 blue-green 을 이용할 것입니다.
   - 현재 자원을 최소한으로 활용할 예정입니다. (불필요한 인프라는 사용 X)
   - session 인증 방식을 적용했을 때 blue-green 배포가 진행될 경우 새로운 버전이 배포될 때 로그인이 모두 해제되는 문제가 발생
   - 그래서 서버에 종속되지 않는 jwt 방식을 채택했습니다.

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #24 
