### PR TITLE
Refactor #54 : 중복 로그인을 허용하지 않는다

### DIFF
--- a/src/main/java/dayone/dayone/auth/application/AuthService.java
+++ b/src/main/java/dayone/dayone/auth/application/AuthService.java
@@ -30,6 +30,11 @@ public class AuthService {
         final User user = userRepository.findByEmailAndPassword(loginRequest.email(), loginRequest.password())
             .orElseThrow(() -> new AuthException(AuthErrorCode.FAIL_LOGIN));
 
+        authTokenRepository.findByUserId(user.getId())
+            .ifPresent(authToken -> {
+                throw new AuthException(AuthErrorCode.ALREADY_LOGIN);
+            });
+
         final String accessToken = tokenProvider.createAccessToken(user.getId());
         final String refreshToken = tokenProvider.createRefreshToken(user.getId());
 

--- a/src/main/java/dayone/dayone/auth/entity/repository/AuthTokenRepository.java
+++ b/src/main/java/dayone/dayone/auth/entity/repository/AuthTokenRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface AuthTokenRepository extends JpaRepository<AuthToken, Long> {
 
     Optional<AuthToken> findByUserIdAndRefreshToken(final Long userId, final String refreshToken);
+
+    Optional<AuthToken> findByUserId(final Long userId);
 }

--- a/src/main/java/dayone/dayone/auth/exception/AuthErrorCode.java
+++ b/src/main/java/dayone/dayone/auth/exception/AuthErrorCode.java
@@ -8,7 +8,8 @@ public enum AuthErrorCode implements ErrorCode {
     FAIL_LOGIN(HttpStatus.BAD_REQUEST, 4001, "이메일 혹은 비밀번호가 틀렸습니다."),
     HAVE_NOT_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 4002, "refresh 토큰이 존재하지 않습니다."),
     NOT_LOGIN_USER(HttpStatus.UNAUTHORIZED, 4003, "로그인되지 않은 유저입니다."),
-    HAVE_WRONG_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 4004, "잘못된 refresh 토큰을 가지고 있습니다.");
+    HAVE_WRONG_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 4004, "잘못된 refresh 토큰을 가지고 있습니다."),
+    ALREADY_LOGIN(HttpStatus.BAD_REQUEST, 4005, "이미 로그인되어 있습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/test/java/dayone/dayone/auth/application/AuthServiceTest.java
+++ b/src/test/java/dayone/dayone/auth/application/AuthServiceTest.java
@@ -100,6 +100,21 @@ class AuthServiceTest extends ServiceTest {
                 Arguments.of(new LoginRequest("test@test.com", "test1"))
             );
         }
+
+        @DisplayName("이미 로그인되 계정으로 로그인 시도 시 예외를 발생한다.")
+        @Test
+        void failLoginWithAlreadyLoginedUser() {
+            // given
+            final User user = testUserFactory.createUser("test@test.com", "test", "test");
+            testAuthTokenFactory.createAuthToken(user.getId(), "refreshToken");
+            final LoginRequest wrongLoginRequest = new LoginRequest(user.getEmail(), user.getPassword());
+
+            // when
+            // then
+            assertThatThrownBy(() -> authService.login(wrongLoginRequest))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(AuthErrorCode.ALREADY_LOGIN.getMessage());
+        }
     }
 
     @DisplayName("token 삭제")


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- 중복 로그인을 허용하지 않도록 로직 수정
    - 로그인 시 현재 계정으로 refreshToken을 가지고 있는지 확인 후 있으면 로그인 허용 X 

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #54 
