### PR TITLE
Refactor #63 : bookLog 응답에 유저 정보를 포함해서 제공 

### DIFF
--- a/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
+++ b/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
@@ -13,8 +13,23 @@ import java.util.List;
 
 public interface BookLogRepository extends JpaRepository<BookLog, Long> {
 
+    @Query("""
+        SELECT bl
+        FROM BookLog bl
+        JOIN FETCH bl.user
+        JOIN FETCH bl.book
+        ORDER BY bl.createdAt DESC
+        """)
     Slice<BookLog> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
+    @Query("""
+        SELECT bl
+        FROM BookLog bl
+        JOIN FETCH bl.user
+        JOIN FETCH bl.book
+        WHERE bl.id < :id
+        ORDER BY bl.createdAt DESC
+        """)
     Slice<BookLog> findAllByIdLessThanOrderByCreatedAtDesc(Long id, Pageable pageable);
 
     @Query("""
@@ -36,6 +51,8 @@ public interface BookLogRepository extends JpaRepository<BookLog, Long> {
     @Query("""
         SELECT bl
         FROM BookLog bl
+        JOIN FETCH bl.user
+        JOIN FETCH bl.book
         WHERE bl.createdAt BETWEEN :monDay AND :sunDay
         """)
     List<BookLog> findAllByCreatedAtBetween(@Param("monDay") final LocalDateTime monDay, @Param("sunDay") final LocalDateTime sunDay);
@@ -43,8 +60,9 @@ public interface BookLogRepository extends JpaRepository<BookLog, Long> {
     @Query("""
         SELECT bl
         FROM BookLog bl
-        JOIN Users u ON bl.user = u
-        WHERE u.id = :id
+        JOIN FETCH bl.user
+        JOIN FETCH bl.book
+        WHERE bl.user.id = :id
         AND bl.createdAt between :monDay and :sunDay
         """)
     List<BookLog> findAllByUserIdAndCreatedAtBetween(@Param("id") final Long userId, @Param("monDay") final LocalDateTime monDay, @Param("sunDay") final LocalDateTime sunDay);

--- a/src/main/java/dayone/dayone/booklog/service/dto/BookLogResponse.java
+++ b/src/main/java/dayone/dayone/booklog/service/dto/BookLogResponse.java
@@ -13,9 +13,12 @@ public record BookLogResponse(
     int likeCnt,
     @JsonProperty("book_title")
     String bookTitle,
+    @JsonProperty("user_name")
+    String userName,
+    @JsonProperty("profile_image")
+    String profileImage,
     @JsonProperty("created_at")
     LocalDateTime createdAt
-    // TODO 유저 정보 추가하기
 ) {
     public static BookLogResponse from(final BookLog bookLog) {
         return new BookLogResponse(bookLog.getId(),
@@ -23,6 +26,8 @@ public record BookLogResponse(
             bookLog.getComment(),
             bookLog.getLikeCount(),
             bookLog.getBook().getTitle(),
+            bookLog.getUser().getName(),
+            bookLog.getUser().getProfileImage(),
             bookLog.getCreatedAt());
     }
 }

--- a/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
+++ b/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
@@ -159,7 +159,7 @@ public class BookLogDocsTest extends DocsTest {
         @Test
         void readBookLogsByCursor() throws Exception {
             // given
-            final List<BookLogResponse> response = List.of(new BookLogResponse(1L, "의미있는 구절", "내가 느낀 감정", 1, "책 제목", LocalDateTime.now()));
+            final List<BookLogResponse> response = List.of(new BookLogResponse(1L, "의미있는 구절", "내가 느낀 감정", 1, "책 제목", "유저", "유저 프로필", LocalDateTime.now()));
 
             given(bookLogService.getAllBookLogs(anyLong()))
                 .willReturn(new BookLogPaginationListResponse(response, false, -1L));
@@ -190,6 +190,8 @@ public class BookLogDocsTest extends DocsTest {
                         fieldWithPath("data.book_logs[].comment").type(JsonFieldType.STRING).description("댓글"),
                         fieldWithPath("data.book_logs[].book_title").type(JsonFieldType.STRING).description("책 제목"),
                         fieldWithPath("data.book_logs[].like_count").type(JsonFieldType.NUMBER).description("책 로그 좋아요 수"),
+                        fieldWithPath("data.book_logs[].user_name").type(JsonFieldType.STRING).description("유저 이름"),
+                        fieldWithPath("data.book_logs[].profile_image").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
                         fieldWithPath("data.book_logs[].created_at").type(JsonFieldType.STRING).description("책 로그 생성 시간"),
                         fieldWithPath("data.next").type(JsonFieldType.BOOLEAN).description("다음 데이터 존재 여부"),
                         fieldWithPath("data.next_cursor").type(JsonFieldType.NUMBER).description("다음 데이터 커서")
@@ -309,10 +311,10 @@ public class BookLogDocsTest extends DocsTest {
         void readMostLikedAndWrittenRecentlyBookLogsInWeek() throws Exception {
             // given
             final List<BookLogResponse> bookLogResponses = List.of(
-                new BookLogResponse(1L, "의미있는 구절", "내가 느낀 감정", 5, "책 제목", LocalDateTime.now()),
-                new BookLogResponse(3L, "의미있는 구절", "내가 느낀 감정", 4, "책 제목", LocalDateTime.now()),
-                new BookLogResponse(2L, "의미있는 구절", "내가 느낀 감정", 4, "책 제목", LocalDateTime.now()),
-                new BookLogResponse(4L, "의미있는 구절", "내가 느낀 감정", 2, "책 제목", LocalDateTime.now())
+                new BookLogResponse(1L, "의미있는 구절", "내가 느낀 감정", 5, "책 제목", "유저", "유저 프로필", LocalDateTime.now()),
+                new BookLogResponse(3L, "의미있는 구절", "내가 느낀 감정", 4, "책 제목", "유저", "유저 프로필", LocalDateTime.now()),
+                new BookLogResponse(2L, "의미있는 구절", "내가 느낀 감정", 4, "책 제목", "유저", "유저 프로필", LocalDateTime.now()),
+                new BookLogResponse(4L, "의미있는 구절", "내가 느낀 감정", 2, "책 제목", "유저", "유저 프로필", LocalDateTime.now())
             );
 
             given(bookLogService.getTop4BookLogs(any()))
@@ -339,6 +341,8 @@ public class BookLogDocsTest extends DocsTest {
                         fieldWithPath("data.book_logs[].comment").type(JsonFieldType.STRING).description("댓글"),
                         fieldWithPath("data.book_logs[].book_title").type(JsonFieldType.STRING).description("책 제목"),
                         fieldWithPath("data.book_logs[].like_count").type(JsonFieldType.NUMBER).description("책 로그 좋아요 수"),
+                        fieldWithPath("data.book_logs[].user_name").type(JsonFieldType.STRING).description("유저 이름"),
+                        fieldWithPath("data.book_logs[].profile_image").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
                         fieldWithPath("data.book_logs[].created_at").type(JsonFieldType.STRING).description("책 로그 생성 시간")
                     )
                 ));


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- bookLog 조회 시 작성자 정보도 함께 제공하는 방식으로 수정
- book과 bookLog는 1 : N으로 연관관계가 맺어져 있고 user와 bookLog는 1 : N 연관관계를 맺고 있는 상황에서 bookLog를 조회할 시 book 정보와 user 정보를 조회할 때 N + 1 문제가 발생 -> 이를 fetch join을 통해서 해결

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가
- 현재 book 정보와 user 정보는 모두가 필요한 것은 아니고 일부분만 필요한 상황이라 추후에 성능 문제가 발생된다면 dto projection을 고려할 수 있을 것 같습니다.

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #63 
