### PR TITLE
Refactor #70 : book log 상세 조회 시 유저 정보를 추가 시킨다.

### DIFF
--- a/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
+++ b/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
@@ -10,8 +10,18 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface BookLogRepository extends JpaRepository<BookLog, Long> {
+
+    @Query("""
+        SELECT bl
+        FROM BookLog bl
+        JOIN FETCH bl.user
+        JOIN FETCH bl.book
+        WHERE bl.id = :id
+        """)
+    Optional<BookLog> findByIdWithUserAndBook(Long id);
 
     @Query("""
         SELECT bl

--- a/src/main/java/dayone/dayone/booklog/service/BookLogService.java
+++ b/src/main/java/dayone/dayone/booklog/service/BookLogService.java
@@ -67,7 +67,7 @@ public class BookLogService {
     }
 
     public BookLogDetailResponse getBookLogById(final Long bookLogId) {
-        final BookLog bookLog = bookLogRepository.findById(bookLogId)
+        final BookLog bookLog = bookLogRepository.findByIdWithUserAndBook(bookLogId)
             .orElseThrow(() -> new BookLogException(BookLogErrorCode.NOT_EXIST_BOOK_LOG));
         return BookLogDetailResponse.of(bookLog);
     }

--- a/src/main/java/dayone/dayone/booklog/service/dto/BookLogDetailResponse.java
+++ b/src/main/java/dayone/dayone/booklog/service/dto/BookLogDetailResponse.java
@@ -15,9 +15,12 @@ public record BookLogDetailResponse(
     String bookTitle,
     @JsonProperty("book_cover")
     String bookCover,
+    @JsonProperty("user_name")
+    String userName,
+    @JsonProperty("profile_image")
+    String profileImage,
     @JsonProperty("created_at")
     LocalDateTime createdAt
-    // TODO : 유저 정보 추가하기
 ) {
     public static BookLogDetailResponse of(final BookLog bookLog) {
         return new BookLogDetailResponse(bookLog.getId(),
@@ -26,6 +29,8 @@ public record BookLogDetailResponse(
             bookLog.getLikeCount(),
             bookLog.getBook().getTitle(),
             bookLog.getBook().getThumbnail(),
+            bookLog.getUser().getName(),
+            bookLog.getUser().getProfileImage(),
             bookLog.getCreatedAt());
     }
 }

--- a/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
+++ b/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
@@ -241,6 +241,8 @@ public class BookLogDocsTest extends DocsTest {
                 0,
                 "책 제목",
                 "책 표지",
+                "유저 이름",
+                "유저 프로필",
                 LocalDateTime.now());
             given(bookLogService.getBookLogById(anyLong()))
                 .willReturn(response);
@@ -270,6 +272,8 @@ public class BookLogDocsTest extends DocsTest {
                         fieldWithPath("data.book_title").description("책 제목"),
                         fieldWithPath("data.book_cover").description("책 표지"),
                         fieldWithPath("data.like_count").description("책 로그의 좋아요 수"),
+                        fieldWithPath("data.user_name").description("유저 이름"),
+                        fieldWithPath("data.profile_image").description("유저 프로필"),
                         fieldWithPath("data.created_at").description("책 로그 생성 시간")
                     )
                 ));

--- a/src/test/java/dayone/dayone/booklog/service/BookLogServiceTest.java
+++ b/src/test/java/dayone/dayone/booklog/service/BookLogServiceTest.java
@@ -163,6 +163,8 @@ class BookLogServiceTest extends ServiceTest {
                 softAssertions.assertThat(response.likeCnt()).isEqualTo(bookLog.getLikeCount());
                 softAssertions.assertThat(response.bookTitle()).isEqualTo(book.getTitle());
                 softAssertions.assertThat(response.bookCover()).isEqualTo(book.getThumbnail());
+                softAssertions.assertThat(response.userName()).isEqualTo(user.getName());
+                softAssertions.assertThat(response.profileImage()).isEqualTo(user.getProfileImage());
                 softAssertions.assertThat(response.createdAt()).isEqualTo(bookLog.getCreatedAt());
             });
         }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)
- book log 상세 조회 과정에서 유저 정보가 필요해 응답 값에 유저 정보를 같이 포함해서 제공한다.
- user 정보를 불러올 때 추가 쿼리를 보내는 대신 join을 통해 쿼리 하나로 처리하는 방안을 택했습니다.

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #70 
