### PR TITLE
Feat #72 : 유저 정보 조회 api 추가

### DIFF
--- a/src/docs/asciidoc/book-log.adoc
+++ b/src/docs/asciidoc/book-log.adoc
@@ -74,20 +74,3 @@ include::{snippets}/read-most-liked-and-written-recently-book-logs-in-week/http-
 ==== 인증되지 않은 유저가 Top4(Best) Book Log 목록을 조회할 경우
 include::{snippets}/read-most-liked-and-written-recently-book-logs-in-week-fail-with-unauthorized-user/response-fields.adoc[]
 include::{snippets}/read-most-liked-and-written-recently-book-logs-in-week-fail-with-unauthorized-user/http-response.adoc[]
-
-== Active Date On Book Log Write In Week Read
-
-=== Request
-include::{snippets}/read-active-date-that-write-book-log-in-week/request-headers.adoc[]
-include::{snippets}/read-active-date-that-write-book-log-in-week/http-request.adoc[]
-
-=== Response
-
-==== 정상적으로 주간 bookLog 작성 날짜를 활성화 정보를 조회한 경우
-include::{snippets}/read-active-date-that-write-book-log-in-week/response-fields.adoc[]
-include::{snippets}/read-active-date-that-write-book-log-in-week/http-response.adoc[]
-
-==== 인증되지 않은 유저가 주간 bookLog 작성 활성화 정보를 조회할 경우
-include::{snippets}/read-active-date-that-write-book-log-in-week-fail-with-unauthorized-user/response-fields.adoc[]
-include::{snippets}/read-active-date-that-write-book-log-in-week-fail-with-unauthorized-user/http-response.adoc[]
-

--- a/src/docs/asciidoc/my-page.adoc
+++ b/src/docs/asciidoc/my-page.adoc
@@ -36,6 +36,22 @@ include::{snippets}/read-user-book-logs/http-response.adoc[]
 include::{snippets}/fail-read-user-book-logs/response-fields.adoc[]
 include::{snippets}/fail-read-user-book-logs/http-response.adoc[]
 
+== Active Date On Book Log Write In Week Read
+
+=== Request
+include::{snippets}/read-active-date-that-write-book-log-in-week/request-headers.adoc[]
+include::{snippets}/read-active-date-that-write-book-log-in-week/http-request.adoc[]
+
+=== Response
+
+==== 정상적으로 주간 bookLog 작성 날짜를 활성화 정보를 조회한 경우
+include::{snippets}/read-active-date-that-write-book-log-in-week/response-fields.adoc[]
+include::{snippets}/read-active-date-that-write-book-log-in-week/http-response.adoc[]
+
+==== 인증되지 않은 유저가 주간 bookLog 작성 활성화 정보를 조회할 경우
+include::{snippets}/read-active-date-that-write-book-log-in-week-fail-with-unauthorized-user/response-fields.adoc[]
+include::{snippets}/read-active-date-that-write-book-log-in-week-fail-with-unauthorized-user/http-response.adoc[]
+
 == User Info Read Api
 
 === Request

--- a/src/docs/asciidoc/my-page.adoc
+++ b/src/docs/asciidoc/my-page.adoc
@@ -35,3 +35,18 @@ include::{snippets}/read-user-book-logs/http-response.adoc[]
 ==== 존재하지 않는 사용자가 책에 작성한 bookLog를 조회할 경우
 include::{snippets}/fail-read-user-book-logs/response-fields.adoc[]
 include::{snippets}/fail-read-user-book-logs/http-response.adoc[]
+
+== User Info Read Api
+
+=== Request
+include::{snippets}/read-user-info/request-headers.adoc[]
+include::{snippets}/read-user-info/http-request.adoc[]
+
+=== Response
+==== 정상적으로 유저 정보를 조회한 경우
+include::{snippets}/read-user-info/response-fields.adoc[]
+include::{snippets}/read-user-info/http-response.adoc[]
+
+==== 존재하지 않는 사용자가 유저 정보를 조회할 경우
+include::{snippets}/fail-read-user-info/response-fields.adoc[]
+include::{snippets}/fail-read-user-info/http-response.adoc[]

--- a/src/main/java/dayone/dayone/user/service/UserService.java
+++ b/src/main/java/dayone/dayone/user/service/UserService.java
@@ -1,0 +1,23 @@
+package dayone.dayone.user.service;
+
+import dayone.dayone.user.entity.User;
+import dayone.dayone.user.entity.repository.UserRepository;
+import dayone.dayone.user.exception.UserErrorCode;
+import dayone.dayone.user.exception.UserException;
+import dayone.dayone.user.service.dto.UserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserInfoResponse getUserInfo(final Long userId) {
+        final User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST_USER));
+
+        return UserInfoResponse.from(user);
+    }
+}

--- a/src/main/java/dayone/dayone/user/service/dto/UserInfoResponse.java
+++ b/src/main/java/dayone/dayone/user/service/dto/UserInfoResponse.java
@@ -1,0 +1,14 @@
+package dayone.dayone.user.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dayone.dayone.user.entity.User;
+
+public record UserInfoResponse(
+    String name,
+    @JsonProperty("profile_image")
+    String profileImage
+) {
+    public static UserInfoResponse from(final User user) {
+        return new UserInfoResponse(user.getName(), user.getProfileImage());
+    }
+}

--- a/src/main/java/dayone/dayone/user/ui/UserController.java
+++ b/src/main/java/dayone/dayone/user/ui/UserController.java
@@ -1,0 +1,24 @@
+package dayone.dayone.user.ui;
+
+import dayone.dayone.auth.ui.argumentresolver.AuthUser;
+import dayone.dayone.global.response.CommonResponseDto;
+import dayone.dayone.user.service.UserService;
+import dayone.dayone.user.service.dto.UserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("api/v1/users")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/info")
+    public CommonResponseDto<UserInfoResponse> getUserInfo(@AuthUser final Long userId) {
+        final UserInfoResponse response = userService.getUserInfo(userId);
+        return CommonResponseDto.forSuccess(1, "유저 정보 조회 성공", response);
+    }
+}

--- a/src/test/java/dayone/dayone/support/DocsTest.java
+++ b/src/test/java/dayone/dayone/support/DocsTest.java
@@ -12,6 +12,7 @@ import dayone.dayone.booklog.service.BookLogService;
 import dayone.dayone.bookloglike.service.BookLogLikeService;
 import dayone.dayone.demoday.service.DemoDayService;
 import dayone.dayone.user.service.UserBookService;
+import dayone.dayone.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -47,6 +48,9 @@ public class DocsTest {
 
     @MockBean
     public DemoDayService demoDayService;
+
+    @MockBean
+    public UserService userService;
 
     @MockBean
     public AuthInterceptor authInterceptor;

--- a/src/test/java/dayone/dayone/user/docs/UserDocsTest.java
+++ b/src/test/java/dayone/dayone/user/docs/UserDocsTest.java
@@ -1,0 +1,80 @@
+package dayone.dayone.user.docs;
+
+import dayone.dayone.support.DocsTest;
+import dayone.dayone.user.service.dto.UserInfoResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class UserDocsTest extends DocsTest {
+
+    @DisplayName("유저 정보를 조회한다.")
+    @Test
+    void readUserInfo() throws Exception {
+        // given
+        successAuth();
+        given(userService.getUserInfo(anyLong()))
+            .willReturn(new UserInfoResponse("유저 이름", "유저 프로필 이미지"));
+
+        // when
+        final ResultActions result = mockMvc.perform(get("/api/v1/users/info")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"));
+
+        // then
+        result.andExpect(status().isOk())
+            .andDo(document("read-user-info",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("인증된 사용자의 accessToken")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("성공 코드 ex) 1"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("성공 메시지 ex) 조회된 유저 정보"),
+                    fieldWithPath("data.name").type(JsonFieldType.STRING).description("유저 이름"),
+                    fieldWithPath("data.profile_image").type(JsonFieldType.STRING).description("유저 프로필 이미지")
+                )
+            ));
+    }
+
+    @DisplayName("유저 정보 조회 시 인증되지 않은 사용자가 조회할 경우 401예외를 발생한다.")
+    @Test
+    void failReadUserInfoWithUnAuthenticatedUser() throws Exception {
+        // given
+        failAuth();
+
+        // when
+        final ResultActions result = mockMvc.perform(get("/api/v1/users/info")
+            .header(HttpHeaders.AUTHORIZATION, "비어있거나 혹은 존재하지 않는 UserToken 정보"));
+
+        // then
+        result.andExpect(status().isUnauthorized())
+            .andDo(document("fail-read-user-info",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("비어 있거나 존재하지 않는 User의 Token 정보")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("실패 코드 ex) 4003"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메세지 ex) 로그인 되지 않은 유저입니다."),
+                    fieldWithPath("data").type(null).description("null")
+                )
+            ));
+    }
+}

--- a/src/test/java/dayone/dayone/user/service/UserBookServiceTest.java
+++ b/src/test/java/dayone/dayone/user/service/UserBookServiceTest.java
@@ -13,7 +13,10 @@ import dayone.dayone.user.service.dto.UserBookListResponse;
 import dayone.dayone.user.service.dto.UserBookLogListResponse;
 import dayone.dayone.user.service.dto.UserBookLogResponse;
 import dayone.dayone.user.service.dto.UserBookResponse;
+import dayone.dayone.user.service.dto.UserInfoResponse;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -41,84 +44,124 @@ class UserBookServiceTest extends ServiceTest {
     @Autowired
     private UserBookService userBookService;
 
-    @DisplayName("유저의 책장 목록을 조회한다.(책장 목록 내 책 정보는 중복되지 않으며 최근에 bookLog를 작성한 순으로 정렬됩니다.)")
-    @MethodSource("BooksUserWriteBookLogAndExceptResponse")
-    @ParameterizedTest
-    void readUserBooks(List<Integer> bookIds, List<Long> exceptBookIds) {
-        // given
-        final User user = testUserFactory.createUser("test@test.com", "password", "이름");
-        final List<Book> books = testBookFactory.createNBook(10, "책", "작가", "출판사");
+    @Autowired
+    private UserService userService;
 
-        bookIds.forEach(bookId -> {
-            final Book book = books.get(bookId);
-            testBookLogFactory.createBookLog(book, user);
-        });
+    @DisplayName("유저의 책장 조회")
+    @Nested
+    class ReadUserBooks {
+        @DisplayName("유저의 책장 목록을 조회한다.(책장 목록 내 책 정보는 중복되지 않으며 최근에 bookLog를 작성한 순으로 정렬됩니다.)")
+        @MethodSource("BooksUserWriteBookLogAndExceptResponse")
+        @ParameterizedTest
+        void readUserBooks(List<Integer> bookIds, List<Long> exceptBookIds) {
+            // given
+            final User user = testUserFactory.createUser("test@test.com", "password", "이름");
+            final List<Book> books = testBookFactory.createNBook(10, "책", "작가", "출판사");
 
-        // when
-        final UserBookListResponse result = userBookService.getUserBooks(user.getId());
+            bookIds.forEach(bookId -> {
+                final Book book = books.get(bookId);
+                testBookLogFactory.createBookLog(book, user);
+            });
 
-        // then
-        final List<Long> resultBookIds = result.userBooks().stream()
-            .map(UserBookResponse::id)
-            .toList();
+            // when
+            final UserBookListResponse result = userBookService.getUserBooks(user.getId());
 
-        assertThat(resultBookIds).usingRecursiveComparison().isEqualTo(exceptBookIds);
+            // then
+            final List<Long> resultBookIds = result.userBooks().stream()
+                .map(UserBookResponse::id)
+                .toList();
+
+            assertThat(resultBookIds).usingRecursiveComparison().isEqualTo(exceptBookIds);
+        }
+
+        // 사용자가 bookLog를 작성한 책 인덱스 정보와 응답 예측 데이터의 정보
+        private static Stream<Arguments> BooksUserWriteBookLogAndExceptResponse() {
+            return Stream.of(
+                arguments(List.of(0, 1, 2), List.of(3L, 2L, 1L)),
+                arguments(List.of(0, 1, 2, 3, 1), List.of(2L, 4L, 3L, 1L)) // 최근에 bookLog를 작성한 순으로 정렬됩니다.
+            );
+        }
+
+        @DisplayName("존재하지 않은 유저가 자신의 책장 목록을 조회하려고 하면 예외를 발생한다.")
+        @Test
+        void readUserBooksWithNotExistUser() {
+            // given
+            final long notExistUserId = Long.MAX_VALUE;
+
+            // when
+            // then
+            assertThatThrownBy(() -> userBookService.getUserBooks(notExistUserId))
+                .isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
+        }
+
+        @DisplayName("유저가 자신의 책에 작성한 bookLog를 불러온다.")
+        @Test
+        void readUserBookLogs() {
+            // given
+            final User user = testUserFactory.createUser("test@test.com", "password", "이름");
+            final Book book = testBookFactory.createBook("책", "작가", "출판사");
+            final BookLog bookLog1 = testBookLogFactory.createBookLog(book, user);
+            final BookLog bookLog2 = testBookLogFactory.createBookLog(book, user);
+            final BookLog bookLog3 = testBookLogFactory.createBookLog(book, user);
+
+            // when
+            final UserBookLogListResponse result = userBookService.getUserBookLogs(user.getId(), book.getId());
+
+            // then
+            final List<Long> expectedBookLogIds = List.of(bookLog3.getId(), bookLog2.getId(), bookLog1.getId());
+
+            final List<Long> resultBookLogIds = result.bookLogs().stream()
+                .map(UserBookLogResponse::id)
+                .toList();
+
+            assertThat(resultBookLogIds).usingRecursiveComparison().isEqualTo(expectedBookLogIds);
+        }
+
+        @DisplayName("존재하지 않는 유저가 책에 작성한 bookLog를 불러오면 예외가 발생한다.")
+        @Test
+        void readUserBookLogsWithNotExistUser() {
+            // given
+            final long notExistUserId = Long.MAX_VALUE;
+            final Book book = testBookFactory.createBook("책", "작가", "출판사");
+
+            // when, then
+            assertThatThrownBy(() -> userBookService.getUserBookLogs(notExistUserId, book.getId()))
+                .isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
+        }
     }
 
-    // 사용자가 bookLog를 작성한 책 인덱스 정보와 응답 예측 데이터의 정보
-    private static Stream<Arguments> BooksUserWriteBookLogAndExceptResponse() {
-        return Stream.of(
-            arguments(List.of(0, 1, 2), List.of(3L, 2L, 1L)),
-            arguments(List.of(0, 1, 2, 3, 1), List.of(2L, 4L, 3L, 1L)) // 최근에 bookLog를 작성한 순으로 정렬됩니다.
-        );
-    }
+    @DisplayName("유저 조회")
+    @Nested
+    public class ReadUser {
+        @DisplayName("유저 정보를 조회한다.")
+        @Test
+        void readUserInfo() {
+            // given
+            final User user = testUserFactory.createUser("test@test.com", "password", "이름");
 
-    @DisplayName("존재하지 않은 유저가 자신의 책장 목록을 조회하려고 하면 예외를 발생한다.")
-    @Test
-    void readUserBooksWithNotExistUser() {
-        // given
-        final long notExistUserId = Long.MAX_VALUE;
+            // when
+            final UserInfoResponse result = userService.getUserInfo(user.getId());
 
-        // when
-        // then
-        assertThatThrownBy(() -> userBookService.getUserBooks(notExistUserId))
-            .isInstanceOf(UserException.class)
-            .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
-    }
+            // then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(result.name()).isEqualTo(user.getName());
+                softAssertions.assertThat(result.profileImage()).isEqualTo(user.getProfileImage());
+            });
+        }
 
-    @DisplayName("유저가 자신의 책에 작성한 bookLog를 불러온다.")
-    @Test
-    void readUserBookLogs() {
-        // given
-        final User user = testUserFactory.createUser("test@test.com", "password", "이름");
-        final Book book = testBookFactory.createBook("책", "작가", "출판사");
-        final BookLog bookLog1 = testBookLogFactory.createBookLog(book, user);
-        final BookLog bookLog2 = testBookLogFactory.createBookLog(book, user);
-        final BookLog bookLog3 = testBookLogFactory.createBookLog(book, user);
+        @DisplayName("존재하지 않는 유저 id로 유저 정보를 조회하면 예외가 발생한다.")
+        @Test
+        void readUserInfoWithNotExistUserId() {
+            // given
+            final long notExistUserId = Long.MAX_VALUE;
 
-        // when
-        final UserBookLogListResponse result = userBookService.getUserBookLogs(user.getId(), book.getId());
-
-        // then
-        final List<Long> expectedBookLogIds = List.of(bookLog3.getId(), bookLog2.getId(), bookLog1.getId());
-
-        final List<Long> resultBookLogIds = result.bookLogs().stream()
-            .map(UserBookLogResponse::id)
-            .toList();
-
-        assertThat(resultBookLogIds).usingRecursiveComparison().isEqualTo(expectedBookLogIds);
-    }
-
-    @DisplayName("존재하지 않는 유저가 책에 작성한 bookLog를 불러오면 예외가 발생한다.")
-    @Test
-    void readUserBookLogsWithNotExistUser() {
-        // given
-        final long notExistUserId = Long.MAX_VALUE;
-        final Book book = testBookFactory.createBook("책", "작가", "출판사");
-
-        // when, then
-        assertThatThrownBy(() -> userBookService.getUserBookLogs(notExistUserId, book.getId()))
-            .isInstanceOf(UserException.class)
-            .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
+            // when
+            // then
+            assertThatThrownBy(() -> userService.getUserInfo(notExistUserId))
+                .isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)
- 마이페이지 접근 시 유저 이름과 프로필 이미지가 필요
- 유저 정보를 조회할 수 있는 api 추가

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #72 
