### PR TITLE
Feat #74 :  유저가 작성한 전체 book log 수 조회 api 추가

### DIFF
--- a/src/docs/asciidoc/my-page.adoc
+++ b/src/docs/asciidoc/my-page.adoc
@@ -66,3 +66,18 @@ include::{snippets}/read-user-info/http-response.adoc[]
 ==== 존재하지 않는 사용자가 유저 정보를 조회할 경우
 include::{snippets}/fail-read-user-info/response-fields.adoc[]
 include::{snippets}/fail-read-user-info/http-response.adoc[]
+
+== User Book Log Write Count Read Api
+
+=== Request
+include::{snippets}/read-user-book-log-count/request-headers.adoc[]
+include::{snippets}/read-user-book-log-count/http-request.adoc[]
+
+=== Response
+==== 정상적으로 유저의 book log 개수를 조회한 경우
+include::{snippets}/read-user-book-log-count/response-fields.adoc[]
+include::{snippets}/read-user-book-log-count/http-response.adoc[]
+
+==== 존재하지 않는 사용자가 유저의 book log 개수를 조회할 경우
+include::{snippets}/fail-read-user-book-log-count-with-unauthorized-user/response-fields.adoc[]
+include::{snippets}/fail-read-user-book-log-count-with-unauthorized-user/http-response.adoc[]

--- a/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
+++ b/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
@@ -76,4 +76,6 @@ public interface BookLogRepository extends JpaRepository<BookLog, Long> {
         AND bl.createdAt between :monDay and :sunDay
         """)
     List<BookLog> findAllByUserIdAndCreatedAtBetween(@Param("id") final Long userId, @Param("monDay") final LocalDateTime monDay, @Param("sunDay") final LocalDateTime sunDay);
+
+    long countByUserId(final Long userId);
 }

--- a/src/main/java/dayone/dayone/booklog/service/BookLogService.java
+++ b/src/main/java/dayone/dayone/booklog/service/BookLogService.java
@@ -15,6 +15,7 @@ import dayone.dayone.booklog.service.dto.BookLogDetailResponse;
 import dayone.dayone.booklog.service.dto.BookLogPaginationListResponse;
 import dayone.dayone.booklog.service.dto.BookLogTop4Response;
 import dayone.dayone.booklog.service.dto.BookLogWriteActiveResponse;
+import dayone.dayone.booklog.service.dto.BookLogWriteCountResponse;
 import dayone.dayone.user.entity.User;
 import dayone.dayone.user.entity.repository.UserRepository;
 import dayone.dayone.user.exception.UserErrorCode;
@@ -93,5 +94,14 @@ public class BookLogService {
 
         BookLogs bookLogs = new BookLogs(bookLogsWrittenThisWeek);
         return BookLogWriteActiveResponse.from(bookLogs.getBookLogWriteActive());
+    }
+
+    public BookLogWriteCountResponse getWriteCount(final Long userId) {
+        userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST_USER));
+
+        final long writingCount = bookLogRepository.countByUserId(userId);
+
+        return new BookLogWriteCountResponse(writingCount);
     }
 }

--- a/src/main/java/dayone/dayone/booklog/service/dto/BookLogWriteCountResponse.java
+++ b/src/main/java/dayone/dayone/booklog/service/dto/BookLogWriteCountResponse.java
@@ -1,0 +1,6 @@
+package dayone.dayone.booklog.service.dto;
+
+public record BookLogWriteCountResponse(
+    long count
+) {
+}

--- a/src/main/java/dayone/dayone/booklog/ui/BookLogController.java
+++ b/src/main/java/dayone/dayone/booklog/ui/BookLogController.java
@@ -7,6 +7,7 @@ import dayone.dayone.booklog.service.dto.BookLogDetailResponse;
 import dayone.dayone.booklog.service.dto.BookLogPaginationListResponse;
 import dayone.dayone.booklog.service.dto.BookLogTop4Response;
 import dayone.dayone.booklog.service.dto.BookLogWriteActiveResponse;
+import dayone.dayone.booklog.service.dto.BookLogWriteCountResponse;
 import dayone.dayone.global.response.CommonResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -56,5 +57,11 @@ public class BookLogController {
     public CommonResponseDto<BookLogWriteActiveResponse> getBookLogWriteActiveInWeek(@AuthUser final Long userId) {
         final BookLogWriteActiveResponse response = bookLogService.getBookLogWriteActive(userId);
         return CommonResponseDto.forSuccess(1, "일주일간 bookLog 작성 날짜 조회 성공", response);
+    }
+
+    @GetMapping("/count")
+    public CommonResponseDto<BookLogWriteCountResponse> getBookLogWriteCount(@AuthUser final Long userId) {
+        final BookLogWriteCountResponse response = bookLogService.getWriteCount(userId);
+        return CommonResponseDto.forSuccess(1, "bookLog 작성 개수 조회 성공", response);
     }
 }

--- a/src/main/java/dayone/dayone/user/service/UserService.java
+++ b/src/main/java/dayone/dayone/user/service/UserService.java
@@ -7,7 +7,9 @@ import dayone.dayone.user.exception.UserException;
 import dayone.dayone.user.service.dto.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class UserService {

--- a/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
+++ b/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
@@ -8,6 +8,7 @@ import dayone.dayone.booklog.service.dto.BookLogPaginationListResponse;
 import dayone.dayone.booklog.service.dto.BookLogResponse;
 import dayone.dayone.booklog.service.dto.BookLogTop4Response;
 import dayone.dayone.booklog.service.dto.BookLogWriteActiveResponse;
+import dayone.dayone.booklog.service.dto.BookLogWriteCountResponse;
 import dayone.dayone.support.DocsTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -433,5 +434,59 @@ public class BookLogDocsTest extends DocsTest {
                 ));
         }
 
+        @DisplayName("유저가 자신의 작성한 bookLog의 개수를 조회한다.")
+        @Test
+        void readUserBookLogCount() throws Exception {
+            // given
+            successAuth();
+            given(bookLogService.getWriteCount(any()))
+                .willReturn(new BookLogWriteCountResponse(1));
+
+            // when
+            final ResultActions result = mockMvc.perform(get("/api/v1/book-logs/count")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+            );
+
+            // then
+            result.andExpect(status().isOk())
+                .andDo(document("read-user-book-log-count",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("인증된 사용자의 accessToken")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("성공 코드 ex) 1"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("성공 메시지 ex) bookLog 작성 개수 조회 성공"),
+                        fieldWithPath("data.count").type(JsonFieldType.NUMBER).description("작성한 book log의 개수")
+                    )
+                ));
+        }
+
+        @DisplayName("인증되지 않은 유저가 작성한 book log 개수를 조회할 경우 401 예외가 발생한다.")
+        @Test
+        void failReadBookLogCountWithUnauthorizedUser() throws Exception {
+            // given
+            failAuth();
+
+            // when
+            final ResultActions result = mockMvc.perform(get("/api/v1/book-logs/count")
+                .header(HttpHeaders.AUTHORIZATION, "비어있거나 혹은 존재하지 않는 UserToken 정보"));
+
+            // then
+            result.andExpect(status().isUnauthorized())
+                .andDo(document("fail-read-user-book-log-count-with-unauthorized-user",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("인증되지 않은 유저의 accessToken")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("실패 코드 ex) 4003"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메세지 ex) 로그인 되지 않은 유저입니다."),
+                        fieldWithPath("data").type(null).description("null")
+                    )
+                ));
+        }
     }
 }

--- a/src/test/java/dayone/dayone/booklog/service/BookLogServiceTest.java
+++ b/src/test/java/dayone/dayone/booklog/service/BookLogServiceTest.java
@@ -11,6 +11,7 @@ import dayone.dayone.booklog.service.dto.BookLogPaginationListResponse;
 import dayone.dayone.booklog.service.dto.BookLogResponse;
 import dayone.dayone.booklog.service.dto.BookLogTop4Response;
 import dayone.dayone.booklog.service.dto.BookLogWriteActiveResponse;
+import dayone.dayone.booklog.service.dto.BookLogWriteCountResponse;
 import dayone.dayone.fixture.TestBookFactory;
 import dayone.dayone.fixture.TestBookLogFactory;
 import dayone.dayone.fixture.TestUserFactory;
@@ -31,6 +32,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -225,6 +227,39 @@ class BookLogServiceTest extends ServiceTest {
             // when
             // then
             assertThatThrownBy(() -> bookLogService.getBookLogWriteActive(notExistUserId))
+                .isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
+        }
+
+        @DisplayName("특정 유저가 작성한 bookLog의 수를 조회한다.")
+        @Test
+        void getBookLogWriteCount() {
+            // given
+            final User user = testUserFactory.createUser("test1@test.com", "password1", "이름1");
+            final User anotherUser = testUserFactory.createUser("test2@test.com", "password2", "이름2");
+
+            final Book book = testBookFactory.createBook("책", "작가", "출판사");
+
+            testBookLogFactory.createBookLog(book, user);
+            testBookLogFactory.createBookLog(book, user);
+            testBookLogFactory.createBookLog(book, anotherUser);
+
+            // when
+            final BookLogWriteCountResponse result = bookLogService.getWriteCount(user.getId());
+
+            // then
+            assertThat(result.count()).isEqualTo(2);
+        }
+
+        @DisplayName("존재하지 않는 유저가 자신이 작성한 bookLog의 수를 조회하면 예외가 발생한다.")
+        @Test
+        void getBookLogWriteCountWithNotExistUser() {
+            // given
+            final long notExistUserId = Long.MAX_VALUE;
+
+            // when
+            // then
+            assertThatThrownBy(() -> bookLogService.getWriteCount(notExistUserId))
                 .isInstanceOf(UserException.class)
                 .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
         }

--- a/src/test/java/dayone/dayone/user/entity/repository/UserRepositoryTest.java
+++ b/src/test/java/dayone/dayone/user/entity/repository/UserRepositoryTest.java
@@ -1,6 +1,5 @@
 package dayone.dayone.user.entity.repository;
 
-import com.jayway.jsonpath.internal.function.sequence.First;
 import dayone.dayone.book.entity.Book;
 import dayone.dayone.book.entity.repository.BookRepository;
 import dayone.dayone.booklog.entity.BookLog;


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- 유저가 작성한 전체 book log 조회 api 추가

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

- 현재는 데이터가 적기에 조회할 때 성능 문제가 없을 것 같지만 데이터가 많아지게 되면 유저 테이블에 반정규화로 가지고 있는 것이 나을지 고민이 되지만 일단 데이터가 쌓여서 문제가 발생했을 때 고민해보겠습니다.

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #74 
