### PR TITLE
Refactor #76 : 로그아웃 api 메소드 delete에서 post로 변경

### DIFF
--- a/src/main/java/dayone/dayone/auth/ui/AuthController.java
+++ b/src/main/java/dayone/dayone/auth/ui/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
         return CommonResponseDto.forSuccess(1, "로그인 성공", new LoginResponse(tokenInfo.accessToken()));
     }
 
-    @DeleteMapping("/logout")
+    @PostMapping("/logout")
     public ResponseEntity<Void> logout(
         @AuthUser final Long userId,
         @CookieValue(value = REFRESH_TOKEN_COOKIE_KEY, defaultValue = EMPTY_REFRESH_TOKEN) final String refreshToken,

--- a/src/test/java/dayone/dayone/auth/docs/AuthDocsTest.java
+++ b/src/test/java/dayone/dayone/auth/docs/AuthDocsTest.java
@@ -87,7 +87,7 @@ public class AuthDocsTest extends DocsTest {
             successAuth();
 
             // when
-            final ResultActions result = mockMvc.perform(delete("/api/v1/auth/logout")
+            final ResultActions result = mockMvc.perform(post("/api/v1/auth/logout")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"));
 
             // then
@@ -111,7 +111,7 @@ public class AuthDocsTest extends DocsTest {
             failAuth();
 
             // when
-            final ResultActions result = mockMvc.perform(delete("/api/v1/auth/logout")
+            final ResultActions result = mockMvc.perform(post("/api/v1/auth/logout")
                 .header(HttpHeaders.AUTHORIZATION, "비어있거나 혹은 존재하지 않는 UserToken 정보"));
 
             // then


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- 로그아웃 api의 메소드를 delete에서 post로 변경

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

생각 정리
- 처음에 delete 메소드를 이용한 이유는 단순히 로그아웃이 삭제의 의미와 가깝다는 단순한 생각이었습니다.
- 하지만 http method 관점에서 delete는 리소스를 삭제하는 것입니다.
- 로그아웃을 한다고 해서 user의 리소스를 삭제하는 것은 아니기에 delete 대신에 post로 변경했습니다.

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #76 
