### PR TITLE
Refactor #69 : 이미 존재하는 책을 저장하려고 할 때 이미 저장된 책의 id를 반환한다.

### DIFF
--- a/src/main/java/dayone/dayone/book/entity/repository/BookRepository.java
+++ b/src/main/java/dayone/dayone/book/entity/repository/BookRepository.java
@@ -3,5 +3,9 @@ package dayone.dayone.book.entity.repository;
 import dayone.dayone.book.entity.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+    Optional<Book> findByIsbn(final String isbn);
 }

--- a/src/main/java/dayone/dayone/book/service/BookService.java
+++ b/src/main/java/dayone/dayone/book/service/BookService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -24,6 +25,10 @@ public class BookService {
 
     @Transactional
     public Long create(final BookCreateRequest request) {
+        final Optional<Book> alreadySavedBook = bookRepository.findByIsbn(request.isbn());
+        if (alreadySavedBook.isPresent()) {
+            return alreadySavedBook.get().getId();
+        }
         Book book = Book.forSave(request.title(), request.author(), request.publisher(), request.thumbnail(), request.isbn());
         bookRepository.save(book);
         return book.getId();

--- a/src/test/java/dayone/dayone/book/service/BookServiceTest.java
+++ b/src/test/java/dayone/dayone/book/service/BookServiceTest.java
@@ -4,6 +4,8 @@ import dayone.dayone.book.entity.Book;
 import dayone.dayone.book.entity.repository.BookRepository;
 import dayone.dayone.book.service.dto.BookCreateRequest;
 import dayone.dayone.book.service.dto.BookSearchResponse;
+import dayone.dayone.fixture.TestBookFactory;
+import dayone.dayone.support.ServiceTest;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,10 +16,14 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
-class BookServiceTest {
+class BookServiceTest extends ServiceTest {
+
+    @Autowired
+    private TestBookFactory testBookFactory;
 
     @MockBean
     private ExternalBookSearch externalBookSearch;
@@ -80,5 +86,19 @@ class BookServiceTest {
             softly.assertThat(book.getThumbnail()).isEqualTo(bookCreateRequest.thumbnail());
             softly.assertThat(book.getIsbn()).isEqualTo(bookCreateRequest.isbn());
         });
+    }
+
+    @DisplayName("이미 존재하는 책이라면 해당 책의 id를 반환한다.")
+    @Test
+    void creatBookWithAlreadyExistedBook() {
+        // given
+        final Book alreadyExistedBook = testBookFactory.createBook("제목", "저자", "판매처");
+        final BookCreateRequest bookCreateRequest = new BookCreateRequest("제목", "저자", "판매처", "이미지", alreadyExistedBook.getIsbn());
+
+        // when
+        final Long savedBookId = bookService.create(bookCreateRequest);
+
+        // then
+        assertThat(savedBookId).isEqualTo(alreadyExistedBook.getId());
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

![image](https://github.com/user-attachments/assets/540fe9a6-981b-417f-b5e6-d2bb12c8ca1a)
- 동일한 책이 중복되어서 db에 저장되는 문제 발생

- 이미 db에 저장된 책 정보를 중복해서 저장하려고 하면 기존의 저장된 책의 id를 반환한다. 

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #69 
