### PR TITLE
Refactor #78 : book log 조회 응답 시 좋아요 누름 정보 포함하도록 수정 

### DIFF
--- a/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
+++ b/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
@@ -1,6 +1,7 @@
 package dayone.dayone.booklog.entity.repository;
 
 import dayone.dayone.booklog.entity.BookLog;
+import dayone.dayone.booklog.entity.repository.dto.BookLogInfoWithIsLike;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,23 +26,25 @@ public interface BookLogRepository extends JpaRepository<BookLog, Long> {
     Optional<BookLogInfoWithIsLike> findByIdWithUserAndBook(Long id);
 
     @Query("""
-        SELECT bl
+        SELECT bl as bookLog, CASE WHEN bll.id IS NOT NULL THEN true ELSE false END AS isLike
         FROM BookLog bl
         JOIN FETCH bl.user
         JOIN FETCH bl.book
+        LEFT JOIN BookLogLike bll ON bll.bookLogId = bl.id AND bll.userId = bl.user.id
         ORDER BY bl.createdAt DESC
         """)
-    Slice<BookLog> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Slice<BookLogInfoWithIsLike> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     @Query("""
-        SELECT bl
+        SELECT bl as bookLog, CASE WHEN bll.id IS NOT NULL THEN true ELSE false END AS isLike
         FROM BookLog bl
         JOIN FETCH bl.user
         JOIN FETCH bl.book
+        LEFT JOIN BookLogLike bll ON bll.bookLogId = bl.id AND bll.userId = bl.user.id
         WHERE bl.id < :id
         ORDER BY bl.createdAt DESC
         """)
-    Slice<BookLog> findAllByIdLessThanOrderByCreatedAtDesc(Long id, Pageable pageable);
+    Slice<BookLogInfoWithIsLike> findAllByIdLessThanOrderByCreatedAtDesc(Long id, Pageable pageable);
 
     @Query("""
         UPDATE BookLog bl

--- a/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
+++ b/src/main/java/dayone/dayone/booklog/entity/repository/BookLogRepository.java
@@ -15,13 +15,14 @@ import java.util.Optional;
 public interface BookLogRepository extends JpaRepository<BookLog, Long> {
 
     @Query("""
-        SELECT bl
+        SELECT bl as bookLog, CASE WHEN bll.id IS NOT NULL THEN true ELSE false END AS isLike
         FROM BookLog bl
         JOIN FETCH bl.user
         JOIN FETCH bl.book
+        LEFT JOIN BookLogLike bll ON bll.bookLogId = bl.id AND bll.userId = bl.user.id
         WHERE bl.id = :id
         """)
-    Optional<BookLog> findByIdWithUserAndBook(Long id);
+    Optional<BookLogInfoWithIsLike> findByIdWithUserAndBook(Long id);
 
     @Query("""
         SELECT bl

--- a/src/main/java/dayone/dayone/booklog/entity/repository/dto/BookLogInfoWithIsLike.java
+++ b/src/main/java/dayone/dayone/booklog/entity/repository/dto/BookLogInfoWithIsLike.java
@@ -1,0 +1,10 @@
+package dayone.dayone.booklog.entity.repository.dto;
+
+import dayone.dayone.booklog.entity.BookLog;
+
+public interface BookLogInfoWithIsLike {
+
+    BookLog getBookLog();
+
+    boolean getIsLike();
+}

--- a/src/main/java/dayone/dayone/booklog/service/BookLogService.java
+++ b/src/main/java/dayone/dayone/booklog/service/BookLogService.java
@@ -60,11 +60,11 @@ public class BookLogService {
 
         // 초기 요청인 경우
         if (cursor == -1L) {
-            final Slice<BookLog> bookLogs = bookLogRepository.findAllByOrderByCreatedAtDesc(pageable);
+            final Slice<BookLogInfoWithIsLike> bookLogs = bookLogRepository.findAllByOrderByCreatedAtDesc(pageable);
             return BookLogPaginationListResponse.of(bookLogs, bookLogs.hasNext());
         }
 
-        final Slice<BookLog> bookLogs = bookLogRepository.findAllByIdLessThanOrderByCreatedAtDesc(cursor, pageable);
+        final Slice<BookLogInfoWithIsLike> bookLogs = bookLogRepository.findAllByIdLessThanOrderByCreatedAtDesc(cursor, pageable);
         return BookLogPaginationListResponse.of(bookLogs, bookLogs.hasNext());
     }
 

--- a/src/main/java/dayone/dayone/booklog/service/BookLogService.java
+++ b/src/main/java/dayone/dayone/booklog/service/BookLogService.java
@@ -8,6 +8,7 @@ import dayone.dayone.booklog.common.DateFinder;
 import dayone.dayone.booklog.entity.BookLog;
 import dayone.dayone.booklog.entity.BookLogs;
 import dayone.dayone.booklog.entity.repository.BookLogRepository;
+import dayone.dayone.booklog.entity.repository.dto.BookLogInfoWithIsLike;
 import dayone.dayone.booklog.exception.BookLogErrorCode;
 import dayone.dayone.booklog.exception.BookLogException;
 import dayone.dayone.booklog.service.dto.BookLogCreateRequest;
@@ -68,9 +69,9 @@ public class BookLogService {
     }
 
     public BookLogDetailResponse getBookLogById(final Long bookLogId) {
-        final BookLog bookLog = bookLogRepository.findByIdWithUserAndBook(bookLogId)
+        final BookLogInfoWithIsLike bookLogInfo = bookLogRepository.findByIdWithUserAndBook(bookLogId)
             .orElseThrow(() -> new BookLogException(BookLogErrorCode.NOT_EXIST_BOOK_LOG));
-        return BookLogDetailResponse.of(bookLog);
+        return BookLogDetailResponse.of(bookLogInfo.getBookLog(), bookLogInfo.getIsLike());
     }
 
     public BookLogTop4Response getTop4BookLogs(final LocalDateTime now) {

--- a/src/main/java/dayone/dayone/booklog/service/dto/BookLogDetailResponse.java
+++ b/src/main/java/dayone/dayone/booklog/service/dto/BookLogDetailResponse.java
@@ -19,10 +19,12 @@ public record BookLogDetailResponse(
     String userName,
     @JsonProperty("profile_image")
     String profileImage,
+    @JsonProperty("is_like")
+    boolean isLike,
     @JsonProperty("created_at")
     LocalDateTime createdAt
 ) {
-    public static BookLogDetailResponse of(final BookLog bookLog) {
+    public static BookLogDetailResponse of(final BookLog bookLog, final boolean isLike) {
         return new BookLogDetailResponse(bookLog.getId(),
             bookLog.getPassage(),
             bookLog.getComment(),
@@ -31,6 +33,7 @@ public record BookLogDetailResponse(
             bookLog.getBook().getThumbnail(),
             bookLog.getUser().getName(),
             bookLog.getUser().getProfileImage(),
+            isLike,
             bookLog.getCreatedAt());
     }
 }

--- a/src/main/java/dayone/dayone/booklog/service/dto/BookLogPaginationListResponse.java
+++ b/src/main/java/dayone/dayone/booklog/service/dto/BookLogPaginationListResponse.java
@@ -1,7 +1,7 @@
 package dayone.dayone.booklog.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import dayone.dayone.booklog.entity.BookLog;
+import dayone.dayone.booklog.entity.repository.dto.BookLogInfoWithIsLike;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
@@ -14,13 +14,13 @@ public record BookLogPaginationListResponse(
     @JsonProperty("next_cursor")
     long nextCursor
 ) {
-    public static BookLogPaginationListResponse of(final Slice<BookLog> bookLogs, final Boolean next) {
+    public static BookLogPaginationListResponse of(final Slice<BookLogInfoWithIsLike> bookLogs, final Boolean next) {
         final List<BookLogResponse> bookLogResponses = bookLogs.stream()
             .map(BookLogResponse::from)
             .collect(Collectors.toList());
 
         if (next) {
-            final long nextCursor = bookLogs.getContent().get(bookLogs.getSize() - 1).getId();
+            final long nextCursor = bookLogs.getContent().get(bookLogs.getSize() - 1).getBookLog().getId();
             return new BookLogPaginationListResponse(bookLogResponses, true, nextCursor);
         }
         return new BookLogPaginationListResponse(bookLogResponses, next, -1);

--- a/src/main/java/dayone/dayone/booklog/service/dto/BookLogResponse.java
+++ b/src/main/java/dayone/dayone/booklog/service/dto/BookLogResponse.java
@@ -2,6 +2,7 @@ package dayone.dayone.booklog.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dayone.dayone.booklog.entity.BookLog;
+import dayone.dayone.booklog.entity.repository.dto.BookLogInfoWithIsLike;
 
 import java.time.LocalDateTime;
 
@@ -17,9 +18,26 @@ public record BookLogResponse(
     String userName,
     @JsonProperty("profile_image")
     String profileImage,
+    @JsonProperty("is_like")
+    boolean isLike,
     @JsonProperty("created_at")
     LocalDateTime createdAt
 ) {
+    public static BookLogResponse from(final BookLogInfoWithIsLike bookLogInfo) {
+        final BookLog bookLog = bookLogInfo.getBookLog();
+        final boolean isLike = bookLogInfo.getIsLike();
+
+        return new BookLogResponse(bookLog.getId(),
+            bookLog.getPassage(),
+            bookLog.getComment(),
+            bookLog.getLikeCount(),
+            bookLog.getBook().getTitle(),
+            bookLog.getUser().getName(),
+            bookLog.getUser().getProfileImage(),
+            isLike,
+            bookLog.getCreatedAt());
+    }
+
     public static BookLogResponse from(final BookLog bookLog) {
         return new BookLogResponse(bookLog.getId(),
             bookLog.getPassage(),
@@ -28,6 +46,7 @@ public record BookLogResponse(
             bookLog.getBook().getTitle(),
             bookLog.getUser().getName(),
             bookLog.getUser().getProfileImage(),
+            false,
             bookLog.getCreatedAt());
     }
 }

--- a/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
+++ b/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
@@ -244,6 +244,7 @@ public class BookLogDocsTest extends DocsTest {
                 "책 표지",
                 "유저 이름",
                 "유저 프로필",
+                false,
                 LocalDateTime.now());
             given(bookLogService.getBookLogById(anyLong()))
                 .willReturn(response);
@@ -275,6 +276,7 @@ public class BookLogDocsTest extends DocsTest {
                         fieldWithPath("data.like_count").description("책 로그의 좋아요 수"),
                         fieldWithPath("data.user_name").description("유저 이름"),
                         fieldWithPath("data.profile_image").description("유저 프로필"),
+                        fieldWithPath("data.is_like").description("책 로그의 좋아요 여부"),
                         fieldWithPath("data.created_at").description("책 로그 생성 시간")
                     )
                 ));

--- a/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
+++ b/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
@@ -160,7 +160,7 @@ public class BookLogDocsTest extends DocsTest {
         @Test
         void readBookLogsByCursor() throws Exception {
             // given
-            final List<BookLogResponse> response = List.of(new BookLogResponse(1L, "의미있는 구절", "내가 느낀 감정", 1, "책 제목", "유저", "유저 프로필", LocalDateTime.now()));
+            final List<BookLogResponse> response = List.of(new BookLogResponse(1L, "의미있는 구절", "내가 느낀 감정", 1, "책 제목", "유저", "유저 프로필", false, LocalDateTime.now()));
 
             given(bookLogService.getAllBookLogs(anyLong()))
                 .willReturn(new BookLogPaginationListResponse(response, false, -1L));
@@ -193,6 +193,7 @@ public class BookLogDocsTest extends DocsTest {
                         fieldWithPath("data.book_logs[].like_count").type(JsonFieldType.NUMBER).description("책 로그 좋아요 수"),
                         fieldWithPath("data.book_logs[].user_name").type(JsonFieldType.STRING).description("유저 이름"),
                         fieldWithPath("data.book_logs[].profile_image").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
+                        fieldWithPath("data.book_logs[].is_like").type(JsonFieldType.BOOLEAN).description("책 로그의 좋아요 여부"),
                         fieldWithPath("data.book_logs[].created_at").type(JsonFieldType.STRING).description("책 로그 생성 시간"),
                         fieldWithPath("data.next").type(JsonFieldType.BOOLEAN).description("다음 데이터 존재 여부"),
                         fieldWithPath("data.next_cursor").type(JsonFieldType.NUMBER).description("다음 데이터 커서")
@@ -318,10 +319,10 @@ public class BookLogDocsTest extends DocsTest {
         void readMostLikedAndWrittenRecentlyBookLogsInWeek() throws Exception {
             // given
             final List<BookLogResponse> bookLogResponses = List.of(
-                new BookLogResponse(1L, "의미있는 구절", "내가 느낀 감정", 5, "책 제목", "유저", "유저 프로필", LocalDateTime.now()),
-                new BookLogResponse(3L, "의미있는 구절", "내가 느낀 감정", 4, "책 제목", "유저", "유저 프로필", LocalDateTime.now()),
-                new BookLogResponse(2L, "의미있는 구절", "내가 느낀 감정", 4, "책 제목", "유저", "유저 프로필", LocalDateTime.now()),
-                new BookLogResponse(4L, "의미있는 구절", "내가 느낀 감정", 2, "책 제목", "유저", "유저 프로필", LocalDateTime.now())
+                new BookLogResponse(1L, "의미있는 구절", "내가 느낀 감정", 5, "책 제목", "유저", "유저 프로필", false, LocalDateTime.now()),
+                new BookLogResponse(3L, "의미있는 구절", "내가 느낀 감정", 4, "책 제목", "유저", "유저 프로필", false, LocalDateTime.now()),
+                new BookLogResponse(2L, "의미있는 구절", "내가 느낀 감정", 4, "책 제목", "유저", "유저 프로필", false, LocalDateTime.now()),
+                new BookLogResponse(4L, "의미있는 구절", "내가 느낀 감정", 2, "책 제목", "유저", "유저 프로필", false, LocalDateTime.now())
             );
 
             given(bookLogService.getTop4BookLogs(any()))
@@ -350,6 +351,7 @@ public class BookLogDocsTest extends DocsTest {
                         fieldWithPath("data.book_logs[].like_count").type(JsonFieldType.NUMBER).description("책 로그 좋아요 수"),
                         fieldWithPath("data.book_logs[].user_name").type(JsonFieldType.STRING).description("유저 이름"),
                         fieldWithPath("data.book_logs[].profile_image").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
+                        fieldWithPath("data.book_logs[].is_like").type(JsonFieldType.BOOLEAN).description("책 로그의 좋아요 여부"),
                         fieldWithPath("data.book_logs[].created_at").type(JsonFieldType.STRING).description("책 로그 생성 시간")
                     )
                 ));

--- a/src/test/java/dayone/dayone/booklog/entity/repository/BookLogRepositoryTest.java
+++ b/src/test/java/dayone/dayone/booklog/entity/repository/BookLogRepositoryTest.java
@@ -69,13 +69,13 @@ class BookLogRepositoryTest extends RepositoryTest {
         bookLogRepository.saveAll(nBookLogWrittenNow);
 
         // when
-        final Slice<BookLog> result = bookLogRepository.findAllByIdLessThanOrderByCreatedAtDesc(11L, pageable);
+        final Slice<BookLogInfoWithIsLike> result = bookLogRepository.findAllByIdLessThanOrderByCreatedAtDesc(11L, pageable);
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(result).hasSize(10);
-            softAssertions.assertThat(result.getContent().get(0).getId()).isEqualTo(10L);
-            softAssertions.assertThat(result.getContent().get(9).getId()).isEqualTo(1L);
+            softAssertions.assertThat(result.getContent().get(0).getBookLog().getId()).isEqualTo(10L);
+            softAssertions.assertThat(result.getContent().get(9).getBookLog().getId()).isEqualTo(1L);
         });
     }
 

--- a/src/test/java/dayone/dayone/booklog/entity/repository/BookLogRepositoryTest.java
+++ b/src/test/java/dayone/dayone/booklog/entity/repository/BookLogRepositoryTest.java
@@ -3,6 +3,7 @@ package dayone.dayone.booklog.entity.repository;
 import dayone.dayone.book.entity.Book;
 import dayone.dayone.book.entity.repository.BookRepository;
 import dayone.dayone.booklog.entity.BookLog;
+import dayone.dayone.booklog.entity.repository.dto.BookLogInfoWithIsLike;
 import dayone.dayone.booklog.entity.value.Comment;
 import dayone.dayone.booklog.entity.value.Passage;
 import dayone.dayone.support.DateConstant;
@@ -45,13 +46,13 @@ class BookLogRepositoryTest extends RepositoryTest {
         bookLogRepository.saveAll(nBookLogWrittenNow);
 
         // when
-        final Slice<BookLog> result = bookLogRepository.findAllByOrderByCreatedAtDesc(pageable);
+        final Slice<BookLogInfoWithIsLike> result = bookLogRepository.findAllByOrderByCreatedAtDesc(pageable);
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(result).hasSize(10);
-            softAssertions.assertThat(result.getContent().get(0).getId()).isEqualTo(20L);
-            softAssertions.assertThat(result.getContent().get(9).getId()).isEqualTo(11L);
+            softAssertions.assertThat(result.getContent().get(0).getBookLog().getId()).isEqualTo(20L);
+            softAssertions.assertThat(result.getContent().get(9).getBookLog().getId()).isEqualTo(11L);
         });
     }
 

--- a/src/test/java/dayone/dayone/booklog/service/BookLogServiceTest.java
+++ b/src/test/java/dayone/dayone/booklog/service/BookLogServiceTest.java
@@ -167,6 +167,7 @@ class BookLogServiceTest extends ServiceTest {
                 softAssertions.assertThat(response.bookCover()).isEqualTo(book.getThumbnail());
                 softAssertions.assertThat(response.userName()).isEqualTo(user.getName());
                 softAssertions.assertThat(response.profileImage()).isEqualTo(user.getProfileImage());
+                softAssertions.assertThat(response.isLike()).isEqualTo(false);
                 softAssertions.assertThat(response.createdAt()).isEqualTo(bookLog.getCreatedAt());
             });
         }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- 연동 과정에서 프론트 화면에서 좋아요 표시를 나타내기 위해서 book log 조회 시 해당 bok log에 좋아요 누름 표시 여부 포함해서 응답하도록 수정

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #78 
