### PR TITLE
Feat #82 : book log 삭제 api 추가

### DIFF
--- a/src/docs/asciidoc/book-log.adoc
+++ b/src/docs/asciidoc/book-log.adoc
@@ -74,3 +74,15 @@ include::{snippets}/read-most-liked-and-written-recently-book-logs-in-week/http-
 ==== 인증되지 않은 유저가 Top4(Best) Book Log 목록을 조회할 경우
 include::{snippets}/read-most-liked-and-written-recently-book-logs-in-week-fail-with-unauthorized-user/response-fields.adoc[]
 include::{snippets}/read-most-liked-and-written-recently-book-logs-in-week-fail-with-unauthorized-user/http-response.adoc[]
+
+== Book Log Delete
+
+=== Request
+include::{snippets}/delete-book-log/request-headers.adoc[]
+include::{snippets}/delete-book-log/path-parameters.adoc[]
+include::{snippets}/delete-book-log/http-request.adoc[]
+
+=== Response
+
+==== 정상적으로 Book Log 삭제를 요청한 경우
+include::{snippets}/delete-book-log/http-response.adoc[]

--- a/src/main/java/dayone/dayone/booklog/entity/BookLog.java
+++ b/src/main/java/dayone/dayone/booklog/entity/BookLog.java
@@ -73,6 +73,10 @@ public class BookLog extends BaseEntity {
         return new BookLog(null, new Passage(passage), new Comment(comment), book, user);
     }
 
+    public boolean isNotWriter(final Long userId) {
+        return !userId.equals(this.user.getId());
+    }
+
     public String getPassage() {
         return this.passage.getValue();
     }

--- a/src/main/java/dayone/dayone/booklog/exception/BookLogErrorCode.java
+++ b/src/main/java/dayone/dayone/booklog/exception/BookLogErrorCode.java
@@ -9,7 +9,8 @@ public enum BookLogErrorCode implements ErrorCode {
     COMMENT_LENGTH_OVER(HttpStatus.BAD_REQUEST, 2, "책에 대한 자신의 생각은 5000자를 넘길 수 없습니다."),
     PASSAGE_BLANK_AND_NULL(HttpStatus.BAD_REQUEST, 3, "구절은 비어있어나 null 일 수 없습니다."),
     PASSAGE_LENGTH_OVER(HttpStatus.BAD_REQUEST, 4, "구절은 1000자를 넘길 수 없습니다."),
-    NOT_EXIST_BOOK_LOG(HttpStatus.NOT_FOUND, 5, "존재하지 않는 책 로그입니다.");
+    NOT_EXIST_BOOK_LOG(HttpStatus.BAD_REQUEST, 5, "존재하지 않는 책 로그입니다."),
+    NOT_BOOK_LOG_WRITER(HttpStatus.BAD_REQUEST, 6, "책 로그 작성자가 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/dayone/dayone/booklog/service/BookLogService.java
+++ b/src/main/java/dayone/dayone/booklog/service/BookLogService.java
@@ -105,4 +105,19 @@ public class BookLogService {
 
         return new BookLogWriteCountResponse(writingCount);
     }
+
+    @Transactional
+    public void delete(final Long userId, final Long bookLogId) {
+        userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST_USER));
+
+        final BookLog bookLog = bookLogRepository.findById(bookLogId)
+            .orElseThrow(() -> new BookLogException(BookLogErrorCode.NOT_EXIST_BOOK_LOG));
+
+        if (bookLog.isNotWriter(userId)) {
+            throw new BookLogException(BookLogErrorCode.NOT_BOOK_LOG_WRITER);
+        }
+
+        bookLogRepository.delete(bookLog);
+    }
 }

--- a/src/main/java/dayone/dayone/booklog/ui/BookLogController.java
+++ b/src/main/java/dayone/dayone/booklog/ui/BookLogController.java
@@ -10,7 +10,9 @@ import dayone.dayone.booklog.service.dto.BookLogWriteActiveResponse;
 import dayone.dayone.booklog.service.dto.BookLogWriteCountResponse;
 import dayone.dayone.global.response.CommonResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,5 +65,11 @@ public class BookLogController {
     public CommonResponseDto<BookLogWriteCountResponse> getBookLogWriteCount(@AuthUser final Long userId) {
         final BookLogWriteCountResponse response = bookLogService.getWriteCount(userId);
         return CommonResponseDto.forSuccess(1, "bookLog 작성 개수 조회 성공", response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@AuthUser final Long userId, @PathVariable("id") final Long bookLogId) {
+        bookLogService.delete(userId, bookLogId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
+++ b/src/test/java/dayone/dayone/booklog/docs/BookLogDocsTest.java
@@ -24,9 +24,11 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -489,6 +491,34 @@ public class BookLogDocsTest extends DocsTest {
                         fieldWithPath("code").type(JsonFieldType.NUMBER).description("실패 코드 ex) 4003"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메세지 ex) 로그인 되지 않은 유저입니다."),
                         fieldWithPath("data").type(null).description("null")
+                    )
+                ));
+        }
+    }
+
+    @DisplayName("bookLog 삭제")
+    @Nested
+    class DeleteBookLog {
+        @DisplayName("유저가 자신의 bookLog를 삭제한다.")
+        @Test
+        void deleteBookLog() throws Exception {
+            // given
+            willDoNothing().given(bookLogService).delete(anyLong(), anyLong());
+            successAuth();
+            // when
+            final ResultActions result = mockMvc.perform(delete("/api/v1/book-logs/{book_log_id}", 1L, 1L)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"));
+
+            // then
+            result.andExpect(status().isNoContent())
+                .andDo(document("delete-book-log",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName("Authorization").description("인증된 사용자의 accessToken")
+                    ),
+                    pathParameters(
+                        parameterWithName("book_log_id").description("삭제할 book log의 id")
                     )
                 ));
         }

--- a/src/test/java/dayone/dayone/booklog/service/BookLogServiceTest.java
+++ b/src/test/java/dayone/dayone/booklog/service/BookLogServiceTest.java
@@ -5,6 +5,8 @@ import dayone.dayone.book.exception.BookErrorCode;
 import dayone.dayone.book.exception.BookException;
 import dayone.dayone.booklog.entity.BookLog;
 import dayone.dayone.booklog.entity.repository.BookLogRepository;
+import dayone.dayone.booklog.exception.BookLogErrorCode;
+import dayone.dayone.booklog.exception.BookLogException;
 import dayone.dayone.booklog.service.dto.BookLogCreateRequest;
 import dayone.dayone.booklog.service.dto.BookLogDetailResponse;
 import dayone.dayone.booklog.service.dto.BookLogPaginationListResponse;
@@ -30,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -261,6 +264,70 @@ class BookLogServiceTest extends ServiceTest {
             // when
             // then
             assertThatThrownBy(() -> bookLogService.getWriteCount(notExistUserId))
+                .isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
+        }
+    }
+
+    @DisplayName("bookLog 삭제")
+    @Nested
+    class DeleteBookLog {
+
+        @DisplayName("bookLog을 작성한 유저가 자신의 bookLog를 삭제한다.")
+        @Test
+        void deleteBookLog() {
+            // given
+            final Book book = testBookFactory.createBook("책", "작가", "출판사");
+            final User user = testUserFactory.createUser("test@test.com", "password", "이름");
+            final BookLog bookLog = testBookLogFactory.createBookLog(book, user);
+
+            // when
+            bookLogService.delete(user.getId(), bookLog.getId());
+
+            // then
+            final Optional<BookLog> deleteBookLog = bookLogRepository.findById(bookLog.getId());
+            assertThat(deleteBookLog).isEmpty();
+        }
+
+        @DisplayName("작성자가 아닌 유저가 bookLog를 삭제하면 예외가 발생한다.")
+        @Test
+        void deleteBookLogWithNotWriter() {
+            // given
+            final Book book = testBookFactory.createBook("책", "작가", "출판사");
+            final User user = testUserFactory.createUser("test@test.com", "password", "이름");
+            final User anotherUser = testUserFactory.createUser("another@test.com", "another", "다른 유저");
+            final BookLog bookLog = testBookLogFactory.createBookLog(book, user);
+
+            // when, then
+            assertThatThrownBy(() -> bookLogService.delete(anotherUser.getId(), bookLog.getId()))
+                .isInstanceOf(BookLogException.class)
+                .hasMessage(BookLogErrorCode.NOT_BOOK_LOG_WRITER.getMessage());
+        }
+
+        @DisplayName("존재하지 않는 bookLog를 삭제하면 예외가 발생한다.")
+        @Test
+        void deleteBookLogWithNotExistBookLog() {
+            // given
+            final User user = testUserFactory.createUser("test@test.com", "password", "이름");
+            final long notExistBookLogId = Long.MAX_VALUE;
+
+            // when, then
+            assertThatThrownBy(() -> bookLogService.delete(user.getId(), notExistBookLogId))
+                .isInstanceOf(BookLogException.class)
+                .hasMessage(BookLogErrorCode.NOT_EXIST_BOOK_LOG.getMessage());
+        }
+
+        @DisplayName("존재하지 않는 유저가 bookLog를 삭제하면 예외가 발생한다.")
+        @Test
+        void deleteBookLogWithNotExistUser() {
+            // given
+            final Book book = testBookFactory.createBook("책", "작가", "출판사");
+            final User user = testUserFactory.createUser("test@test.com", "password", "이름");
+            final BookLog bookLog = testBookLogFactory.createBookLog(book, user);
+            final long notExistUserId = Long.MAX_VALUE;
+
+            // when, then
+            assertThatThrownBy(() -> bookLogService.delete(notExistUserId, bookLog.getId()))
                 .isInstanceOf(UserException.class)
                 .hasMessage(UserErrorCode.NOT_EXIST_USER.getMessage());
         }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- book log 삭제 api 추가했습니다.
    - 인증되지 않은 유저가 요청 시 예외처리
    - 존재하지 않은 book log를 삭제 요청 시 예외처리
    - book log 작성자가 아닌 유저가 삭제 요청 시 예외처리 

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #82 
