### PR TITLE
Feature #87 : 유저 프로필 이미지 업데이트 기능 추가

### DIFF
--- a/src/docs/asciidoc/my-page.adoc
+++ b/src/docs/asciidoc/my-page.adoc
@@ -81,3 +81,13 @@ include::{snippets}/read-user-book-log-count/http-response.adoc[]
 ==== 존재하지 않는 사용자가 유저의 book log 개수를 조회할 경우
 include::{snippets}/fail-read-user-book-log-count-with-unauthorized-user/response-fields.adoc[]
 include::{snippets}/fail-read-user-book-log-count-with-unauthorized-user/http-response.adoc[]
+
+== Update User Profile Image
+
+=== Request
+include::{snippets}/update-user-profile-image/request-headers.adoc[]
+include::{snippets}/update-user-profile-image/request-parts.adoc[]
+include::{snippets}/update-user-profile-image/http-request.adoc[]
+
+=== Response
+include::{snippets}/update-user-profile-image/http-response.adoc[]

--- a/src/main/java/dayone/dayone/user/entity/User.java
+++ b/src/main/java/dayone/dayone/user/entity/User.java
@@ -43,4 +43,8 @@ public class User extends BaseEntity {
     public static User forSave(final String email, final String password, final String name) {
         return new User(null, email, password, name, "기본 이미지");
     }
+
+    public void updateProfileImage(final String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/dayone/dayone/user/service/UserService.java
+++ b/src/main/java/dayone/dayone/user/service/UserService.java
@@ -1,5 +1,6 @@
 package dayone.dayone.user.service;
 
+import dayone.dayone.global.service.FileService;
 import dayone.dayone.user.entity.User;
 import dayone.dayone.user.entity.repository.UserRepository;
 import dayone.dayone.user.exception.UserErrorCode;
@@ -8,6 +9,9 @@ import dayone.dayone.user.service.dto.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -15,11 +19,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final FileService filesService;
 
     public UserInfoResponse getUserInfo(final Long userId) {
         final User user = userRepository.findById(userId)
             .orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST_USER));
 
         return UserInfoResponse.from(user);
+    }
+
+    @Transactional
+    public void updateUserProfileImage(final Long userId, final MultipartFile file) throws IOException {
+        final User user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST_USER));
+
+        final String newProfileImage = filesService.uploadFile(file);
+        user.updateProfileImage(newProfileImage);
     }
 }

--- a/src/main/java/dayone/dayone/user/ui/UserController.java
+++ b/src/main/java/dayone/dayone/user/ui/UserController.java
@@ -5,9 +5,16 @@ import dayone.dayone.global.response.CommonResponseDto;
 import dayone.dayone.user.service.UserService;
 import dayone.dayone.user.service.dto.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RequiredArgsConstructor
 @RequestMapping("api/v1/users")
@@ -20,5 +27,11 @@ public class UserController {
     public CommonResponseDto<UserInfoResponse> getUserInfo(@AuthUser final Long userId) {
         final UserInfoResponse response = userService.getUserInfo(userId);
         return CommonResponseDto.forSuccess(1, "유저 정보 조회 성공", response);
+    }
+
+    @PatchMapping("/update-profile-image")
+    public ResponseEntity<Void> updateUserProfileImage(@AuthUser final Long userId, @RequestPart("file") final MultipartFile file) throws IOException {
+        userService.updateUserProfileImage(userId, file);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/dayone/dayone/support/TestConfig.java
+++ b/src/test/java/dayone/dayone/support/TestConfig.java
@@ -1,0 +1,20 @@
+package dayone.dayone.support;
+
+import dayone.dayone.user.entity.repository.UserRepository;
+import dayone.dayone.user.service.StaticFileService;
+import dayone.dayone.user.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Bean
+    UserService userService() {
+        return new UserService(userRepository, new StaticFileService());
+    }
+}

--- a/src/test/java/dayone/dayone/user/docs/UserDocsTest.java
+++ b/src/test/java/dayone/dayone/user/docs/UserDocsTest.java
@@ -5,20 +5,27 @@ import dayone.dayone.user.service.dto.UserInfoResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class UserDocsTest extends DocsTest {
@@ -76,5 +83,44 @@ public class UserDocsTest extends DocsTest {
                     fieldWithPath("data").type(null).description("null")
                 )
             ));
+    }
+
+    @DisplayName("사용자의 프로필 이미지를 업데이트한다.")
+    @Test
+    void updateUserProfileImage() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "profile.png",
+            "image/png",
+            "dummy image content".getBytes()
+        );
+        successAuth();
+        willDoNothing().given(userService).updateUserProfileImage(anyLong(), any());
+
+        // when
+        final ResultActions result = mockMvc.perform(multipart("/api/v1/users/update-profile-image")
+            .file(file)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+            .with(request -> {
+                request.setMethod("PATCH");
+                request.setContentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+                return request;
+            }));
+
+        // then
+        result.andExpect(status().isNoContent())
+            .andDo(document("update-user-profile-image",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName("Authorization").description("인증된 사용자의 accessToken"),
+                    headerWithName("Content-Type").description("multipart/form-data 요청")
+                ),
+                requestParts(
+                    partWithName("file").description("업로드할 프로필 이미지 파일")
+                )
+            ));
+
     }
 }

--- a/src/test/java/dayone/dayone/user/service/StaticFileService.java
+++ b/src/test/java/dayone/dayone/user/service/StaticFileService.java
@@ -1,0 +1,12 @@
+package dayone.dayone.user.service;
+
+import dayone.dayone.global.service.FileService;
+import org.springframework.web.multipart.MultipartFile;
+
+public class StaticFileService implements FileService {
+
+    @Override
+    public String uploadFile(MultipartFile file) {
+        return "updatedFile";
+    }
+}

--- a/src/test/java/dayone/dayone/user/service/UserServiceTest.java
+++ b/src/test/java/dayone/dayone/user/service/UserServiceTest.java
@@ -1,0 +1,43 @@
+package dayone.dayone.user.service;
+
+import dayone.dayone.fixture.TestUserFactory;
+import dayone.dayone.support.ServiceTest;
+import dayone.dayone.support.TestConfig;
+import dayone.dayone.user.entity.User;
+import dayone.dayone.user.entity.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import({TestConfig.class})
+class UserServiceTest extends ServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestUserFactory testUserFactory;
+
+    @Autowired
+    private UserService userService;
+
+    @DisplayName("사용자의 프로필 사진을 수정한다.")
+    @Test
+    void updateUserProfileImage() throws IOException {
+        // given
+        final User user = testUserFactory.createUser("test@test.com", "password", "이름");
+
+        // when
+        userService.updateUserProfileImage(user.getId(), new MockMultipartFile("test", "test".getBytes()));
+
+        // then
+        User updateUser = userRepository.findById(user.getId()).get();
+        assertThat(updateUser.getProfileImage()).isEqualTo("updatedFile"); // 이미지 업로드 테스트 필요
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

- 사용자 프로필을 업데이트 하는 api를 추가했습니다.

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

- 테스트를 진행하던 중에 jpa의 더티채킹을 실행되지 않아 1시간 가량을 삽질한 경험을 했습니다.
    - UserService 내 필드로 FileService가 있어 테스트에서는 실제 데이터를 저장하는 대신 문자열을 반환하는 객체를 만들었고 이를 테스트에서 활용하기 위해 `new UserService(userRepository, new StaticFileService())`를 이용했지만 테스트가 실패하는 문제 발생 
    - spring bean으로 등록된 객체을 이용해야 transaction이 적용된다는 것을 배웠습니다.
    - `TestConfiguration`을 이용해서 `new UserService(userRepository, new StaticFileService())`를 bean으로 등록하고 `@Import`를 통해 테스트에 적용해서 해결했습니다.

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #87 
