### PR TITLE
Refactor #89 : restClient timeout 설정 추가

### DIFF
--- a/src/main/java/dayone/dayone/book/service/NaverBookSearch.java
+++ b/src/main/java/dayone/dayone/book/service/NaverBookSearch.java
@@ -2,11 +2,16 @@ package dayone.dayone.book.service;
 
 import dayone.dayone.book.service.dto.BookSearchListResponse;
 import dayone.dayone.book.service.dto.BookSearchResponse;
+import dayone.dayone.global.exception.restclient.RestClientErrorCode;
+import dayone.dayone.global.exception.restclient.RestClientException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,18 +36,27 @@ public class NaverBookSearch implements ExternalBookSearch {
     public List<BookSearchResponse> searchBooks(final String name) {
         String url = String.format("%s?query=%s&display=%d", bookSearchUrl, name, RESULT_DATA_COUNT);
 
-        // TODO: 요청이 실패한 경우에 대해서는 어떻게 처리할지 고민하기
-        final BookSearchListResponse response = restClient.get()
-            .uri(url)
-            .header("X-Naver-Client-Id", clientId)
-            .header("X-Naver-Client-Secret", clientSecret)
-            .retrieve()
-            .body(BookSearchListResponse.class);
+        try {
+            final BookSearchListResponse response = restClient.get()
+                .uri(url)
+                .header("X-Naver-Client-Id", clientId)
+                .header("X-Naver-Client-Secret", clientSecret)
+                .retrieve()
+                .body(BookSearchListResponse.class);
 
-        if (response == null || response.items() == null) {
-            return Collections.emptyList();
+            if (response == null || response.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            return response.items();
+        } catch (ResourceAccessException e) {
+            if (e.getCause() instanceof SocketTimeoutException) {
+                throw new RestClientException(RestClientErrorCode.READ_TIMEOUT);
+            } else if (e.getCause() instanceof ConnectException) {
+                throw new RestClientException(RestClientErrorCode.CONNECTION_TIMEOUT);
+            } else {
+                throw new RestClientException(RestClientErrorCode.UNKNOWN_ERROR);
+            }
         }
-
-        return response.items();
     }
 }

--- a/src/main/java/dayone/dayone/book/service/dto/BookSearchListResponse.java
+++ b/src/main/java/dayone/dayone/book/service/dto/BookSearchListResponse.java
@@ -5,4 +5,7 @@ import java.util.List;
 public record BookSearchListResponse(
     List<BookSearchResponse> items
 ) {
+    public boolean isEmpty() {
+        return this.items() == null || this.items().isEmpty();
+    }
 }

--- a/src/main/java/dayone/dayone/global/config/RestClientConfiguration.java
+++ b/src/main/java/dayone/dayone/global/config/RestClientConfiguration.java
@@ -1,14 +1,28 @@
 package dayone.dayone.global.config;
 
+import org.springframework.boot.web.client.ClientHttpRequestFactories;
+import org.springframework.boot.web.client.ClientHttpRequestFactorySettings;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
 
 @Configuration
 public class RestClientConfiguration {
 
     @Bean
     public RestClient getRestClient() {
-        return RestClient.create();
+        return RestClient.builder()
+            .requestFactory(customRequestFactory())
+            .build();
+    }
+
+    ClientHttpRequestFactory customRequestFactory() {
+        ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.DEFAULTS
+            .withConnectTimeout(Duration.ofSeconds(5))
+            .withReadTimeout(Duration.ofSeconds(5));
+        return ClientHttpRequestFactories.get(settings);
     }
 }

--- a/src/main/java/dayone/dayone/global/exception/restclient/RestClientErrorCode.java
+++ b/src/main/java/dayone/dayone/global/exception/restclient/RestClientErrorCode.java
@@ -1,0 +1,36 @@
+package dayone.dayone.global.exception.restclient;
+
+import dayone.dayone.global.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum RestClientErrorCode implements ErrorCode {
+
+    CONNECTION_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, 10001, "연결 시간이 초과되었습니다."),
+    READ_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, 10002, "읽기 시간이 초과되었습니다."),
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 10003, "알 수 없는 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    RestClientErrorCode(final HttpStatus httpStatus, final int code, final String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/dayone/dayone/global/exception/restclient/RestClientException.java
+++ b/src/main/java/dayone/dayone/global/exception/restclient/RestClientException.java
@@ -1,0 +1,10 @@
+package dayone.dayone.global.exception.restclient;
+
+import dayone.dayone.global.exception.CommonException;
+import dayone.dayone.global.exception.ErrorCode;
+
+public class RestClientException extends CommonException {
+    public RestClientException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

해당 작업을 수행 배경
- 외부 api의 연결과정이 지연되거나 혹은 데이터를 읽어오는 과정이 지연되는 경우 db connection이 문제가 될 수 있다고 판단했고 이를 직접 실험해보았습니다.
- 40초의 연결지연이 발생하는 상황에서 100명의 사용자가 요청을 보낼 경우 아래와 같은 에러 발생
![error](https://github.com/user-attachments/assets/e8dcb386-c73e-46f0-b50d-a098922c4f36)


작업 내용
- 외부 api 통신에 이용되는 restClient timeout 설정 추가
- 현재 timeout 설정 시간은 connection timeout, read timeout은 모두 5초로 설정했습니다 (https://whatap.io/bbs/board.php?bo_table=blog&wr_id=66 참고 + 제 경험을 바탕으로 추론했습니다.)

참고자료
- https://www.baeldung.com/spring-rest-timeout

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가

고민사항

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #89 
