### PR TITLE
Feature #96 : 데모데이 신청 시 발생할 수 있는 동시성 문제 해결하기

### DIFF
--- a/src/main/java/dayone/dayone/demoday/entity/respository/DemoDayUserRepository.java
+++ b/src/main/java/dayone/dayone/demoday/entity/respository/DemoDayUserRepository.java
@@ -1,13 +1,22 @@
 package dayone.dayone.demoday.entity.respository;
 
 import dayone.dayone.demoday.entity.DemoDayUser;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface DemoDayUserRepository extends JpaRepository<DemoDayUser, Long> {
+
     Optional<DemoDayUser> findByDemoDayIdAndUserId(final Long demoDayId, final Long userId);
 
     List<DemoDayUser> findByDemoDayId(final Long demoDayId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT D FROM DemoDayUser D WHERE D.demoDayId = :demoDayId")
+    List<DemoDayUser> findByDemoDayIdForUpdate(final @Param("demoDayId") Long demoDayId);
 }

--- a/src/main/java/dayone/dayone/demoday/entity/respository/TicketRepository.java
+++ b/src/main/java/dayone/dayone/demoday/entity/respository/TicketRepository.java
@@ -1,11 +1,19 @@
 package dayone.dayone.demoday.entity.respository;
 
 import dayone.dayone.demoday.entity.Ticket;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     Optional<Ticket> findByDemoDayId(final Long demoDayId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT T FROM Ticket T WHERE T.demoDay.id = :demoDayId")
+    Optional<Ticket> findByDemoDayIdForUpdate(final @Param("demoDayId") Long demoDayId);
 }

--- a/src/main/java/dayone/dayone/demoday/service/DemoDayService.java
+++ b/src/main/java/dayone/dayone/demoday/service/DemoDayService.java
@@ -63,7 +63,7 @@ public class DemoDayService {
             .orElseThrow(() -> new UserException(DemoDayErrorCode.NOT_EXIST_DEMO_DAY));
         final Ticket ticket = ticketRepository.findByDemoDayIdForUpdate(demoDayId)
             .orElseThrow(() -> new UserException(DemoDayErrorCode.NOT_EXIST_DEMO_DAY));
-        final List<DemoDayUser> demoDayUsers = demoDayUserRepository.findByDemoDayId(demoDayId);
+        final List<DemoDayUser> demoDayUsers = demoDayUserRepository.findByDemoDayIdForUpdate(demoDayId);
 
         final DemoDayUser apply = demoDay.apply(user, ticket, new DemoDayUsers(demoDayUsers));
         demoDayUserRepository.save(apply);

--- a/src/main/java/dayone/dayone/demoday/service/DemoDayService.java
+++ b/src/main/java/dayone/dayone/demoday/service/DemoDayService.java
@@ -61,7 +61,7 @@ public class DemoDayService {
             .orElseThrow(() -> new UserException(UserErrorCode.NOT_EXIST_USER));
         final DemoDay demoDay = demoDayRepository.findById(demoDayId)
             .orElseThrow(() -> new UserException(DemoDayErrorCode.NOT_EXIST_DEMO_DAY));
-        final Ticket ticket = ticketRepository.findByDemoDayId(demoDayId)
+        final Ticket ticket = ticketRepository.findByDemoDayIdForUpdate(demoDayId)
             .orElseThrow(() -> new UserException(DemoDayErrorCode.NOT_EXIST_DEMO_DAY));
         final List<DemoDayUser> demoDayUsers = demoDayUserRepository.findByDemoDayId(demoDayId);
 

--- a/src/test/java/dayone/dayone/demoday/service/DemoDayServiceTest.java
+++ b/src/test/java/dayone/dayone/demoday/service/DemoDayServiceTest.java
@@ -27,6 +27,9 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -148,6 +151,38 @@ class DemoDayServiceTest extends ServiceTest {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(ticket.getCapacity()).isEqualTo(0);
                 softly.assertThat(byDemoDayIdAndUserId.isPresent()).isTrue();
+            });
+        }
+
+        @DisplayName("티켓의 개수가 1개인 데모데이에 10명의 유저가 동시에 참여 요청을 하더라도 1명한 참여 가능하다.")
+        @Test
+        void applyDemoDayWithConcurrent() throws InterruptedException {
+            // given
+            final User DemoDayOwner = testUserFactory.createUser("test@test.com", "test", "test", 1);
+            final List<User> users = testUserFactory.createNUser(10, "test2@test.com", "test2", "test2", 1);
+
+
+            final DemoDay demoDayOpen = testDemoDayFactory.createDemoDayOpen("title", "description", DemoDayOwner.getId());
+            final Ticket tickets = testTicketFactory.createNTicket(demoDayOpen, 1);
+
+            final ExecutorService executorService = Executors.newFixedThreadPool(users.size());
+            final CountDownLatch countDownLatch = new CountDownLatch(users.size());
+
+            // when
+            for (final User user : users) {
+                executorService.submit(() -> {
+                    demoDayService.applyDemoDay(user.getId(), demoDayOpen.getId());
+                    countDownLatch.countDown();
+                });
+            }
+            countDownLatch.await();
+
+            // then
+            final List<DemoDayUser> result = demoDayUserRepository.findByDemoDayId(demoDayOpen.getId());
+            final Ticket ticket = ticketRepository.findByDemoDayId(demoDayOpen.getId()).get();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(tickets.getCapacity());
+                softly.assertThat(ticket.getCapacity()).isEqualTo(0);
             });
         }
     }

--- a/src/test/java/dayone/dayone/demoday/service/DemoDayServiceTest.java
+++ b/src/test/java/dayone/dayone/demoday/service/DemoDayServiceTest.java
@@ -193,5 +193,44 @@ class DemoDayServiceTest extends ServiceTest {
                 softly.assertThat(errorCount.get()).isEqualTo(users.size() - 1);
             });
         }
+
+        @DisplayName("같은 유저가 빠르게 2번 데모데이에 신청하더라도 1번만 신청 처리된다.")
+        @Test
+        void applyDemoDayWithConcurrentSameUser() throws InterruptedException {
+            // given
+            final User DemoDayOwner = testUserFactory.createUser("test@test.com", "test", "test", 1);
+            final DemoDay demoDayOpen = testDemoDayFactory.createDemoDayOpen("title", "description", DemoDayOwner.getId());
+            testTicketFactory.createNTicket(demoDayOpen, 2);
+
+            final User demodayUser = testUserFactory.createUser("test2@test.com", "test2", "test2", 1);
+
+            final int threadCount = 2;
+            final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+            // when
+            final AtomicInteger errorCount = new AtomicInteger(0);
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        demoDayService.applyDemoDay(demodayUser.getId(), demoDayOpen.getId());
+                    } catch (Exception ignored) {
+                        errorCount.incrementAndGet();
+                    } finally {
+                        countDownLatch.countDown();
+                    }
+                });
+            }
+            countDownLatch.await();
+
+            // then
+            final List<DemoDayUser> demoDayUsers = demoDayUserRepository.findByDemoDayId(demoDayOpen.getId());
+            final Ticket ticket = ticketRepository.findByDemoDayId(demoDayOpen.getId()).get();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(demoDayUsers).hasSize(1);
+                softly.assertThat(ticket.getCapacity()).isEqualTo(1);
+                softly.assertThat(errorCount.get()).isEqualTo(threadCount - 1);
+            });
+        }
     }
 }

--- a/src/test/java/dayone/dayone/demoday/service/DemoDayServiceTest.java
+++ b/src/test/java/dayone/dayone/demoday/service/DemoDayServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -169,20 +170,27 @@ class DemoDayServiceTest extends ServiceTest {
             final CountDownLatch countDownLatch = new CountDownLatch(users.size());
 
             // when
+            final AtomicInteger errorCount = new AtomicInteger(0);
             for (final User user : users) {
                 executorService.submit(() -> {
-                    demoDayService.applyDemoDay(user.getId(), demoDayOpen.getId());
-                    countDownLatch.countDown();
+                    try {
+                        demoDayService.applyDemoDay(user.getId(), demoDayOpen.getId());
+                    } catch (Exception ignored) {
+                        errorCount.incrementAndGet();
+                    } finally {
+                        countDownLatch.countDown();
+                    }
                 });
             }
+
             countDownLatch.await();
 
-            // then
-            final List<DemoDayUser> result = demoDayUserRepository.findByDemoDayId(demoDayOpen.getId());
+            final List<DemoDayUser> demoDayUsers = demoDayUserRepository.findByDemoDayId(demoDayOpen.getId());
             final Ticket ticket = ticketRepository.findByDemoDayId(demoDayOpen.getId()).get();
             SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(result).hasSize(tickets.getCapacity());
+                softly.assertThat(demoDayUsers).hasSize(tickets.getCapacity());
                 softly.assertThat(ticket.getCapacity()).isEqualTo(0);
+                softly.assertThat(errorCount.get()).isEqualTo(users.size() - 1);
             });
         }
     }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

작업내용
- demoday 신청 시 발생할 수 있는 동시성 문제를 해결한다.
    - demoday 가용 수 보다 많은 사용자가 동시에 참여 신청을 한 경우
    - 같은 사용자가 빠른 클릭을 통한 참여 신청을 시도한 경우 
- 비관적 락을 활용한 동시성 제어 방법 채택
     - synchronized의 경우는 spring의 aop로 인해 의도한 대로 동작하지 않았습니다.
     - 낙관적락을 사용하지 않은 이유는 demoday 신청 마감이 다가올 수록 충돌이 발생하는 상황이 발생할 것이라 생각해 적용하지 않았습니다.(실제로도 신청 마감일이 다가올 수록 신청 빈도가 높은 것으로 확인)
     - 현재 다른 요청에서는 해당 테이블에 x-lock을 걸고 처리하는 요청이 없어 비관적락을 통해 문제를 해결하고자 했습니다. (x-lock의 경우 demoday 신청과 연관있는 테이블의 레코드(ticket과 demodayUser)에만 걸 수 있도록 구성)

## 💬 작업 시 고민사항

> 기능을 추가하거나 수정하는 상황에서 의문이 생긴 점이나 배운점 추가  

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

- close #96 
